### PR TITLE
Add dbus permissions file

### DIFF
--- a/org.openscapd.conf
+++ b/org.openscapd.conf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?> <!-- -*- XML -*- -->
+
+<!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+
+  <!-- Only root can own the service -->
+  <policy user="root">
+    <allow own="org.OpenSCAP.daemon"/>
+  </policy>
+
+  <!-- Allow anyone to invoke methods on the interfaces,
+       authorization is performed by PolicyKit -->
+  <policy context="default">
+    <allow send_destination="org.OpenSCAP.daemon"/>
+  </policy>
+
+</busconfig>


### PR DESCRIPTION
    In order to run as a SystemBus, we need to install a file
    into /etc/dbus-1/system.d/ that sets the permissions
    for openscap-daemon.