### PR TITLE
Minor tweak to conform to oscap_docker_python API

### DIFF
--- a/openscap_daemon/cve_scanner/cve_scanner.py
+++ b/openscap_daemon/cve_scanner/cve_scanner.py
@@ -226,11 +226,7 @@ class Worker(object):
         self.scan_list = image_list
         cve_get = getInputCVE(self.image_tmp)
 
-        # If we find a tarball of the dist break outs and
-        # it is less than 12 hours old, use it to speed things
-        # up
-
-        cve_get.fetch_dist_data(12)
+        cve_get.fetch_dist_data()
 
         threads = []
 


### PR DESCRIPTION
    Just a minor tweak to reflect a small change in one of the
    definition calls in oscap-docker.  The change is being
    tracked against https://github.com/OpenSCAP/openscap/pull/162