### PR TITLE
Fix threading issue with CVE scanning

### DIFF
--- a/openscap_daemon/cve_scanner/scanner_client.py
+++ b/openscap_daemon/cve_scanner/scanner_client.py
@@ -35,7 +35,7 @@ class Client(object):
     ''' The image-scanner client API '''
 
     image_tmp = "/var/tmp/image-scanner"
-    db_timeout = 99
+    db_timeout = 99999
     tup_names = ['number', 'workdir', 'logfile', 'nocache',
                  'reportdir']
     tup = collections.namedtuple('args', tup_names)


### PR DESCRIPTION
    Recent work by Martin has conflicted with with the
    threading model I implemented in the CVE scanning where
    I used a threading.enumerate() to determine the number
    of currently running threads.  Instead of this approach,
    I now just manually track the number of threads.

    Also, extended the dbus timeout for CVE dbus calls.