### PR TITLE
cve_scanning: Allow users to not pull latest OVAL

### DIFF
--- a/openscap_daemon/cve_scanner/applicationconfiguration.py
+++ b/openscap_daemon/cve_scanner/applicationconfiguration.py
@@ -52,7 +52,7 @@ class ApplicationConfiguration(Singleton):
         self.logfile = parserargs.logfile
         self.number = parserargs.number
         self.reportdir = parserargs.reportdir
-        self.nocache = parserargs.nocache
+        self.onlycache = parserargs.onlycache
         self.fcons = None
         self.cons = None
         self.images = None

--- a/openscap_daemon/cve_scanner/scan.py
+++ b/openscap_daemon/cve_scanner/scan.py
@@ -28,6 +28,7 @@ import xml.etree.ElementTree as ET
 import platform
 import StringIO
 from Atomic.mount import DockerMount
+from openscap_daemon.cve_scanner.scanner_error import ImageScannerClientError
 
 # TODO: External dep!
 import rpm
@@ -103,9 +104,10 @@ class Scan(object):
                '--results',
                os.path.join(self.report_dir,
                             self.image_name + '.xml'), self.chroot_cve_file]
-
-        self.result = subprocess.check_output(cmd)
-
+        try:
+            self.result = subprocess.check_output(cmd)
+        except Exception:
+            pass
     # def capture_run(self, cmd):
     #     '''
     #     Subprocess command that captures and returns the output and
@@ -125,6 +127,10 @@ class Scan(object):
         return cons
 
     def report_results(self):
+        if not os.path.exists(self.chroot_cve_file):
+            raise ImageScannerClientError("Unable to find {0}"
+                                          .format(self.chroot_cve_file))
+            return False
         cve_tree = ET.parse(self.chroot_cve_file)
         self.cve_root = cve_tree.getroot()
 

--- a/openscap_daemon/cve_scanner/scanner_client.py
+++ b/openscap_daemon/cve_scanner/scanner_client.py
@@ -36,21 +36,21 @@ class Client(object):
 
     image_tmp = "/var/tmp/image-scanner"
     db_timeout = 99999
-    tup_names = ['number', 'workdir', 'logfile', 'nocache',
+    tup_names = ['number', 'workdir', 'logfile', 'onlycache',
                  'reportdir']
     tup = collections.namedtuple('args', tup_names)
 
     def __init__(self, number=2,
                  logfile=os.path.join(image_tmp, "openscap.log"),
-                 nocache=False,
+                 onlycache=False,
                  reportdir=image_tmp, workdir=image_tmp):
 
         self.arg_tup = self.tup(number=number, logfile=logfile,
-                                nocache=nocache, reportdir=reportdir,
+                                onlycache=onlycache, reportdir=reportdir,
                                 workdir=workdir)
 
         self.arg_dict = {'number': number, 'logfile': logfile,
-                         'nocache': nocache, 'reportdir': reportdir,
+                         'onlycache': onlycache, 'reportdir': reportdir,
                          'workdir': workdir}
         self._docker_ping()
         self.num_threads = number
@@ -58,7 +58,7 @@ class Client(object):
         self.dbus_object = self.bus.get_object(dbus_utils.BUS_NAME,
                                                dbus_utils.OBJECT_PATH)
         self.logfile = logfile
-        self.nocache = nocache
+        self.onlycache = onlycache
         self.reportdir = reportdir
         self.workdir = workdir
         self.onlyactive = False

--- a/openscap_daemon/dbus_daemon.py
+++ b/openscap_daemon/dbus_daemon.py
@@ -326,23 +326,23 @@ class OpenSCAPDaemonDbus(dbus.service.Object):
         return json.dumps(cons)
 
     @dbus.service.method(dbus_interface=dbus_utils.DBUS_INTERFACE,
-                         in_signature='bbi', out_signature='s')
-    def scan_containers(self, onlyactive, allcontainers, number):
+                         in_signature='bbib', out_signature='s')
+    def scan_containers(self, onlyactive, allcontainers, number, onlycache=False):
         worker = Worker(onlyactive=onlyactive, allcontainers=allcontainers,
-                        number=number)
+                        number=number, onlycache=onlycache)
         return_json = worker.start_application()
         return json.dumps(return_json)
 
-    @dbus.service.method(dbus_interface=dbus_utils.DBUS_INTERFACE, in_signature='bbi',
+    @dbus.service.method(dbus_interface=dbus_utils.DBUS_INTERFACE, in_signature='bbib',
                          out_signature='s')
-    def scan_images(self, allimages, images, number):
-        worker = Worker(allimages=allimages, images=images, number=number)
+    def scan_images(self, allimages, images, number, onlycache=False):
+        worker = Worker(allimages=allimages, images=images, number=number, onlycache=onlycache)
         return_json = worker.start_application()
         return json.dumps(return_json)
 
     @dbus.service.method(dbus_interface=dbus_utils.DBUS_INTERFACE,
-                         in_signature='asi', out_signature='s')
-    def scan_list(self, scan_list, number):
-        worker = Worker(scan=scan_list, number=number)
+                         in_signature='asib', out_signature='s')
+    def scan_list(self, scan_list, number, onlycache=False):
+        worker = Worker(scan=scan_list, number=number, onlycache=onlycache)
         return_json = worker.start_application()
         return json.dumps(return_json)


### PR DESCRIPTION
    * Due to a requirement from Atomic, we added an optional parameter
      in the dbus daemon calls to NOT fetch the latest CVE OVAL data
      and only use what is currently in the image.