### PR TITLE
Expose config.ini to host

### DIFF
--- a/atomic/rhel7_spc/Dockerfile
+++ b/atomic/rhel7_spc/Dockerfile
@@ -32,7 +32,7 @@ ADD install.sh /root/
 
 LABEL INSTALL="docker run -t --rm --privileged -v /:/host/ IMAGE sh /root/install.sh"
 
-LABEL RUN="docker run -dt --privileged --pid=host -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /var/tmp/image-scanner:/var/tmp/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN --ipc=host IMAGE"
+LABEL RUN="docker run -dt --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /var/tmp/image-scanner:/var/tmp/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN --ipc=host IMAGE"
 
 # Dockerfile reference discourages "ADD" with remote source
 # I would love to tag this with NOCACHE but Dockerfile doesn't have an

--- a/atomic/rhel7_spc/install.sh
+++ b/atomic/rhel7_spc/install.sh
@@ -1,4 +1,31 @@
 set -x
 
+ETC='/etc/oscapd'
+ETC_FILE='config.ini'
+HOST='/host'
+
 echo "Adding the dbus configuration for the openscap-daemon to the host"
 cp -v /etc/dbus-1/system.d/org.oscapd.conf /host/etc/dbus-1/system.d/
+
+DATE=`date +'%Y-%m-%M-%T'
+
+# Check if /etc/oscapd exists on the host
+if [[ ! -d ${HOST}/${ETC} ]]; then
+    mkdir ${HOST}/${ETC}
+fi
+
+# Check if /etc/oscapd/config.ini exists
+
+if [[ -f ${HOST}/${ETC}/${ETC_FILE} ]]; then
+    SAVE_NAME=${ETC_FILE}.${DATE}.atomic_save
+    echo "Saving current ${ETC_FILE} as ${SAVE_NAME}"
+    mv ${HOST}/${ETC}/${ETC_FILE} ${HOST}/${ETC}/${SAVE_NAME}
+
+# Add config.ini to the host filesystem
+echo "Updating ${ETC_FILE} with latest configuration"
+cp ${ETC}/${ETC_FILE} ${HOST}/${ETC}
+
+# Exit Message
+
+echo "Install complete.  Be sure to customize ${ETC}/${ETC_FILE} as needed"
+


### PR DESCRIPTION
    * During the install, we now copy the config.ini to the host
    * Add bind mount for /etc/oscapd to RUN label