### PR TITLE
Re-implement fetch-cve option for oscapd

### DIFF
--- a/openscap_daemon/cve_scanner/applicationconfiguration.py
+++ b/openscap_daemon/cve_scanner/applicationconfiguration.py
@@ -24,30 +24,10 @@ from openscap_daemon.cve_scanner.scanner_error import ImageScannerClientError
 import docker
 
 
-class Singleton(object):
-    ''' Singleton class to pass references'''
-    _instance = None
-
-    def __new__(cls, *args, **kwargs):
-        if cls._instance is None:
-            instance = super(Singleton, cls).__new__(cls)
-            instance._singleton_init(*args, **kwargs)
-            cls._instance = instance
-        return cls._instance
-
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def _singleton_init(self, *args, **kwargs):
-        """Initialize a singleton instance before it is registered."""
-        pass
-
-
-class ApplicationConfiguration(Singleton):
+class ApplicationConfiguration(object):
     '''Application Configuration'''
-    def _singleton_init(self, parserargs=None):
+    def __init__(self, parserargs=None):
         ''' Init for Application Configuration '''
-        super(ApplicationConfiguration, self)._singleton_init()
         self.workdir = parserargs.workdir
         self.logfile = parserargs.logfile
         self.number = parserargs.number
@@ -78,7 +58,3 @@ class ApplicationConfiguration(Singleton):
             client = None
             raise ImageScannerClientError(error)
         return client
-
-    def __init__(self, parserargs=None):
-        ''' init '''
-        pass

--- a/openscap_daemon/cve_scanner/cve_scanner.py
+++ b/openscap_daemon/cve_scanner/cve_scanner.py
@@ -42,9 +42,9 @@ import collections
 
 class ContainerSearch(object):
     ''' Does a series of docker queries to setup variables '''
-    def __init__(self):
+    def __init__(self, appc):
         self.dead_cids = []
-        self.ac = ApplicationConfiguration()
+        self.ac = appc
         self.cons = self.ac.conn.containers(all=True)
         self.active_containers = self.ac.conn.containers(all=False)
         self.allimages = self.ac.conn.images(name=None, quiet=False,
@@ -130,8 +130,8 @@ class Worker(object):
         self.procs = self.set_procs(self.args.number)
         if not os.path.exists(self.ac.workdir):
             os.makedirs(self.ac.workdir)
-        self.cs = ContainerSearch()
-        self.output = Reporter()
+        self.cs = ContainerSearch(self.ac)
+        self.output = Reporter(self.ac)
 
         self.scan_list = None
         self.failed_scan = None
@@ -240,7 +240,7 @@ class Worker(object):
         cve_get = getInputCVE(self.image_tmp)
         if self.ac.fetch_cve_url != "":
             cve_get.url = self.ac.fetch_cve_url
-        if not self.ac.onlycache:
+        if self.ac.onlycache:
             cve_get.fetch_dist_data()
         threads = []
 
@@ -277,7 +277,7 @@ class Worker(object):
         sys.exit(0)
 
     def search_containers(self, image, cids, output):
-        f = Scan(image, cids, output)
+        f = Scan(image, cids, output, self.ac)
         try:
             if f.get_release():
 

--- a/openscap_daemon/cve_scanner/reporter.py
+++ b/openscap_daemon/cve_scanner/reporter.py
@@ -18,20 +18,17 @@
 
 '''Reporter Class'''
 
-from openscap_daemon.cve_scanner.applicationconfiguration \
-    import ApplicationConfiguration
-
 import collections
 import os
 
 
 class Reporter(object):
     ''' Does stdout reporting '''
-    def __init__(self):
+    def __init__(self, appc):
         self.output = collections.namedtuple('Summary', 'iid, cid, os, sevs,'
                                              'log, msg',)
         self.list_of_outputs = []
-        self.appc = ApplicationConfiguration()
+        self.appc = appc
         self.report_dir = os.path.join(self.appc.reportdir, "reports")
         self.appc.docker_state = os.path.join(self.report_dir,
                                               "docker_state.json")

--- a/openscap_daemon/cve_scanner/scan.py
+++ b/openscap_daemon/cve_scanner/scan.py
@@ -16,9 +16,6 @@
 # Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 # Boston, MA 02111-1307, USA.
 
-from openscap_daemon.cve_scanner.applicationconfiguration \
-    import ApplicationConfiguration
-
 import os
 import collections
 import time
@@ -35,9 +32,9 @@ import rpm
 
 
 class Scan(object):
-    def __init__(self, image_uuid, con_uuids, output):
+    def __init__(self, image_uuid, con_uuids, output, appc):
         self.image_name = image_uuid
-        self.ac = ApplicationConfiguration()
+        self.ac = appc
         self.CVEs = collections.namedtuple('CVEs', 'title, severity,'
                                            'cve_ref_id, cve_ref_url,'
                                            'rhsa_ref_id, rhsa_ref_url')

--- a/openscap_daemon/dbus_daemon.py
+++ b/openscap_daemon/dbus_daemon.py
@@ -325,6 +325,7 @@ class OpenSCAPDaemonDbus(dbus.service.Object):
         cons = self.docker_conn.containers(all=True)
         return json.dumps(cons)
 
+    @staticmethod
     def _parse_only_cache(config, onlycache):
         if onlycache == 2:
             return not config.fetch_cve
@@ -346,7 +347,7 @@ class OpenSCAPDaemonDbus(dbus.service.Object):
         """
         worker = Worker(onlyactive=onlyactive, allcontainers=allcontainers,
                         number=number,
-                        onlycache=self._parse_only_cache(self.system.config, onlycache),
+                        onlycache=self._parse_only_cache(self.system.config, int(onlycache)),
                         fetch_cve_url=self.system.config.fetch_cve_url)
         return_json = worker.start_application()
         return json.dumps(return_json)
@@ -361,7 +362,7 @@ class OpenSCAPDaemonDbus(dbus.service.Object):
         """
         worker = Worker(allimages=allimages, images=images,
                         number=number,
-                        onlycache=self._parse_only_cache(self.system.config, onlycache),
+                        onlycache=self._parse_only_cache(self.system.config, int(onlycache)),
                         fetch_cve_url=self.system.config.fetch_cve_url)
         return_json = worker.start_application()
         return json.dumps(return_json)
@@ -375,7 +376,7 @@ class OpenSCAPDaemonDbus(dbus.service.Object):
             2 to use defaults from oscapd config file
         """
         worker = Worker(scan=scan_list, number=number,
-                        onlycache=self._parse_only_cache(self.system.config, onlycache),
+                        onlycache=self._parse_only_cache(self.system.config, int(onlycache)),
                         fetch_cve_url=self.system.config.fetch_cve_url)
         return_json = worker.start_application()
         return json.dumps(return_json)


### PR DESCRIPTION
    * Based on the agreement with Martin and DWalsh, we now
      have an option for oscapd as to whether to fetch the most
      recent cve input data.

    * The singleton class previously used had to be refactored
      because of the daemonization and the need to change options
      each 'scan'.  Instead of using the singleton implementation,
      we now pass the applicationConfiguration class to other
      classes as an object.

    * Made small correction to convert the byte onlycache to an
      int for equality checking.