### PR TITLE
Add timestamp to task & result

### DIFF
--- a/bin/oscapd-cli
+++ b/bin/oscapd-cli
@@ -69,7 +69,9 @@ def cli_print_results_table(dbus_iface, task_id, result_ids,
             task_id, result_id
         )
         status = oscap_helpers.get_status_from_exit_code(exit_code)
-        table.append([str(result_id), "TODO", status])
+        timestamp = dbus_iface.GetResultCreatedTimestamp(task_id, result_id)
+
+        table.append([str(result_id), datetime.fromtimestamp(timestamp), status])
 
     cli_helpers.print_table(table)
 

--- a/bin/oscapd-cli
+++ b/bin/oscapd-cli
@@ -83,13 +83,20 @@ def cli_task(dbus_iface, args):
     if args.task_id is None:
         # args.task_action is ignored in this scope
 
-        table = [["ID", "Title", "Target", "Enabled"]]
+        table = [["ID", "Title", "Target", "Created", "Modified", "Enabled"]]
         task_ids = dbus_iface.ListTaskIDs()
 
         enabled_count = 0
         for task_id in task_ids:
             title = dbus_iface.GetTaskTitle(task_id, utf8_strings=True)
             target = dbus_iface.GetTaskTarget(task_id, utf8_strings=True)
+
+            created_timestamp = dbus_iface.GetTaskCreatedTimestamp(task_id)
+            created = datetime.fromtimestamp(created_timestamp)
+
+            modified_timestamp = dbus_iface.GetTaskModifiedTimestamp(task_id)
+            modified = datetime.fromtimestamp(modified_timestamp)
+
             enabled = dbus_iface.GetTaskEnabled(task_id)
             if enabled:
                 enabled_count += 1
@@ -98,6 +105,8 @@ def cli_task(dbus_iface, args):
                 str(task_id),
                 title,
                 target,
+                created,
+                modified,
                 # TODO: Maybe we can show the disabled state in a better way?
                 "enabled" if enabled else "disabled"
             ])
@@ -112,10 +121,18 @@ def cli_task(dbus_iface, args):
             title = dbus_iface.GetTaskTitle(args.task_id, utf8_strings=True)
             target = dbus_iface.GetTaskTarget(args.task_id, utf8_strings=True)
 
+            created_timestamp = dbus_iface.GetTaskCreatedTimestamp(args.task_id)
+            created = datetime.fromtimestamp(created_timestamp)
+
+            modified_timestamp = dbus_iface.GetTaskModifiedTimestamp(args.task_id)
+            modified = datetime.fromtimestamp(modified_timestamp)
+
             table = []
             table.append(["Title", title])
             table.append(["ID", str(args.task_id)])
             table.append(["Target", target])
+            table.append(["Created", created])
+            table.append(["Modified", modified])
             cli_helpers.print_table(table, first_row_header=False)
             print("")
 

--- a/openscap_daemon/dbus_daemon.py
+++ b/openscap_daemon/dbus_daemon.py
@@ -265,6 +265,13 @@ class OpenSCAPDaemonDbus(dbus.service.Object):
         return self.system.get_task_result_ids(task_id)
 
     @dbus.service.method(dbus_interface=dbus_utils.DBUS_INTERFACE,
+                         in_signature="xx", out_signature="x")
+    def GetResultCreatedTimestamp(self, task_id, result_id):
+        """Return timestamp of result creation
+        """
+        return self.system.get_task_result_created_timestamp(task_id, result_id)
+
+    @dbus.service.method(dbus_interface=dbus_utils.DBUS_INTERFACE,
                          in_signature="xx", out_signature="s")
     def GetARFOfTaskResult(self, task_id, result_id):
         """Retrieves full ARF of result of given task.

--- a/openscap_daemon/dbus_daemon.py
+++ b/openscap_daemon/dbus_daemon.py
@@ -177,6 +177,20 @@ class OpenSCAPDaemonDbus(dbus.service.Object):
         return self.system.get_task_target(task_id)
 
     @dbus.service.method(dbus_interface=dbus_utils.DBUS_INTERFACE,
+                         in_signature="x", out_signature="x")
+    def GetTaskCreatedTimestamp(self, task_id):
+        """Get timestamp of task creation
+        """
+        return self.system.get_task_created_timestamp(task_id)
+
+    @dbus.service.method(dbus_interface=dbus_utils.DBUS_INTERFACE,
+                         in_signature="x", out_signature="x")
+    def GetTaskModifiedTimestamp(self, task_id):
+        """Get timestamp of task modification
+        """
+        return self.system.get_task_modified_timestamp(task_id)
+
+    @dbus.service.method(dbus_interface=dbus_utils.DBUS_INTERFACE,
                          in_signature="xs", out_signature="")
     def SetTaskInput(self, task_id, input_):
         """Set input of existing task with given ID.

--- a/openscap_daemon/system.py
+++ b/openscap_daemon/system.py
@@ -275,6 +275,14 @@ class System(object):
 
         return task.evaluation_spec.target
 
+    def get_task_created_timestamp(self, task_id):
+        task_path = self._get_task_file_path(task_id)
+        return os.path.getctime(task_path)
+
+    def get_task_modified_timestamp(self, task_id):
+        task_path = self._get_task_file_path(task_id)
+        return os.path.getmtime(task_path)
+
     def set_task_input(self, task_id, input_):
         """input can be an absolute file path or the XML source itself. This is
         autodetected.

--- a/openscap_daemon/system.py
+++ b/openscap_daemon/system.py
@@ -192,6 +192,9 @@ class System(object):
         os.remove(os.path.join(self.config.tasks_dir, "%i.xml" % (task_id)))
         logging.info("Removed task '%i'.", task_id)
 
+    def _get_task_file_path(self, task_id):
+        return os.path.join(self.config.tasks_dir, "%i.xml" % (task_id))
+
     def remove_task_results(self, task_id):
         task = None
 

--- a/openscap_daemon/system.py
+++ b/openscap_daemon/system.py
@@ -529,6 +529,13 @@ class System(object):
         # TODO: Is this a race condition? look into task.update
         return task.list_result_ids(self.config.results_dir)
 
+    def get_task_result_created_timestamp(self, task_id, result_id):
+        task = None
+        with self.tasks_lock:
+            task = self.tasks[task_id]
+
+        return task.get_result_created_timestamp(result_id, self.config)
+
     def get_arf_of_task_result(self, task_id, result_id):
         task = None
         with self.tasks_lock:

--- a/openscap_daemon/system.py
+++ b/openscap_daemon/system.py
@@ -189,7 +189,7 @@ class System(object):
                 task.remove_results(self.config)
             del self.tasks[task_id]
 
-        os.remove(os.path.join(self.config.tasks_dir, "%i.xml" % (task_id)))
+        os.remove(self._get_task_file_path(task_id))
         logging.info("Removed task '%i'.", task_id)
 
     def _get_task_file_path(self, task_id):

--- a/openscap_daemon/task.py
+++ b/openscap_daemon/task.py
@@ -303,6 +303,18 @@ class Task(object):
             key=lambda s: (len(s), s)
         )
 
+    def get_result_created_timestamp(self, result_id, config):
+        """Return timestamp of result creation.
+        """
+        # todo refactor - the path is used from many places
+        file_path = os.path.join(
+            self._get_task_results_dir(config.results_dir),
+            str(result_id),
+            "exit_code"
+        )
+        timestamp = os.path.getctime(file_path)
+        return timestamp
+
     def _get_next_target_dir(self, results_dir):
         # We may consider having a file that contains the last ID in the
         # future. I considered that but right now I think a result with more


### PR DESCRIPTION
solve https://github.com/OpenSCAP/openscap-daemon/issues/17

Maybe "Created" instead of "Timestamp" in output would be better.

```
$ ./bin/oscapd-cli task
\---+---------------------------------------+-----------+---------------------+---------------------+--------
ID | Title                                 | Target    | Created             | Modified            | Enabled
---+---------------------------------------+-----------+---------------------+---------------------+--------
1  | Weekly SCAP Security Guide Evaluation | localhost | 2015-10-20 13:57:47 | 2015-10-20 13:57:48 | enabled

$ ./bin/oscapd-cli task 1
Title    | Weekly SCAP Security Guide Evaluation
ID       | 1                                    
Target   | localhost                            
Created  | 2015-10-20 13:57:47                  
Modified | 2015-10-20 13:57:48                  

Latest results:
---+---------------------+----------
ID | Timestamp           | Status   
---+---------------------+----------
4  | 2015-10-20 13:30:00 | Compliant
3  | 2015-10-20 12:31:09 | Compliant
2  | 2015-10-20 12:27:17 | Compliant
1  | 2015-10-20 11:28:36 | Compliant

$ ./bin/oscapd-cli result 1
Results of Task "Weekly SCAP Security Guide Evaluation", ID = 1

---+---------------------+----------
ID | Timestamp           | Status   
---+---------------------+----------
4  | 2015-10-20 13:30:00 | Compliant
3  | 2015-10-20 12:31:09 | Compliant
2  | 2015-10-20 12:27:17 | Compliant
1  | 2015-10-20 11:28:36 | Compliant

```