### PR TITLE
Support vm-image:// and vm-domain:// target URIs

### DIFF
--- a/openscap_daemon/oscap_helpers.py
+++ b/openscap_daemon/oscap_helpers.py
@@ -156,6 +156,14 @@ def get_evaluation_args(spec, config):
         container_name = spec.target[len("docker-container://"):]
         ret.extend([config.oscap_docker_path, "container", container_name])
 
+    elif spec.target.startswith("vm-domain://"):
+        domain_name = spec.target[len("vm-domain://"):]
+        ret.extend([config.oscap_vm_path, "domain", domain_name])
+
+    elif spec.target.startswith("vm-image://"):
+        storage_name = spec.target[len("vm-image://"):]
+        ret.extend([config.oscap_vm_path, "image", storage_name])
+
     else:
         raise RuntimeError(
             "Unrecognized target '%s' in evaluation spec." % (spec.target)


### PR DESCRIPTION
oscapd -v
```
DEBUG:Starting evaluation with command '/usr/local/bin/oscap-vm image rhel7.0-4 xccdf eval --profile xccdf_org.ssgproject.content_profile_common --results-arf arf.xml /tmp/tmplTsI9g'.
ERROR:Evaluated EvaluationSpec, unknown exit code 139!.
```
When I run it directly
```/usr/local/bin/oscap-vm image rhel7.0-4 xccdf eval --profile xccdf_org.ssgproject.content_profile_common --results-arf arf.xml /tmp/tmplTsI9g```, it returns segfault too
/usr/local/bin/oscap-vm: line 117: 23496 Segmentation fault      (core dumped) oscap "$@"

maybe it is problem only on my computer

I will try to find problem, but it is probably not problem of this pull request

Issue https://github.com/OpenSCAP/openscap-daemon/issues/15
