### PR TITLE
Upstream OVAL file name changes, compressed files

### DIFF
--- a/openscap_daemon/cve_scanner/applicationconfiguration.py
+++ b/openscap_daemon/cve_scanner/applicationconfiguration.py
@@ -32,7 +32,7 @@ class ApplicationConfiguration(object):
         self.logfile = parserargs.logfile
         self.number = parserargs.number
         self.reportdir = parserargs.reportdir
-        self.onlycache = parserargs.onlycache
+        self.fetch_cve = parserargs.fetch_cve
         self.fcons = None
         self.cons = None
         self.images = None

--- a/openscap_daemon/cve_scanner/cve_scanner.py
+++ b/openscap_daemon/cve_scanner/cve_scanner.py
@@ -105,7 +105,7 @@ class Worker(object):
     max_procs = 4
     image_tmp = "/var/tmp/image-scanner"
     scan_args = ['allcontainers', 'allimages', 'images', 'logfile',
-                 'onlycache', 'number', 'onlyactive', 'reportdir',
+                 'fetch_cve', 'number', 'onlyactive', 'reportdir',
                  'workdir', 'url_root', 'host', 'rest_host',
                  'rest_port', 'scan', 'fetch_cve_url']
 
@@ -113,13 +113,13 @@ class Worker(object):
 
     def __init__(self, number=2,
                  logfile=os.path.join(image_tmp, "openscap.log"),
-                 onlycache=False, reportdir=image_tmp, workdir=image_tmp,
+                 fetch_cve=False, reportdir=image_tmp, workdir=image_tmp,
                  host='unix://var/run/docker.sock',
                  allcontainers=False, onlyactive=False, allimages=False,
                  images=False, scan=[], fetch_cve_url=""):
         self.args =\
             self.scan_tuple(number=number, logfile=logfile,
-                            onlycache=onlycache, reportdir=reportdir,
+                            fetch_cve=fetch_cve, reportdir=reportdir,
                             workdir=workdir, host=host,
                             allcontainers=allcontainers, allimages=allimages,
                             onlyactive=onlyactive, images=images, url_root='',
@@ -240,7 +240,7 @@ class Worker(object):
         cve_get = getInputCVE(self.image_tmp)
         if self.ac.fetch_cve_url != "":
             cve_get.url = self.ac.fetch_cve_url
-        if self.ac.onlycache:
+        if self.ac.fetch_cve:
             cve_get.fetch_dist_data()
         threads = []
 

--- a/openscap_daemon/dbus_daemon.py
+++ b/openscap_daemon/dbus_daemon.py
@@ -361,57 +361,57 @@ class OpenSCAPDaemonDbus(dbus.service.Object):
         return json.dumps(cons)
 
     @staticmethod
-    def _parse_only_cache(config, onlycache):
-        if onlycache == 2:
-            return not config.fetch_cve
-        elif onlycache == 1:
+    def _parse_only_cache(config, fetch_cve):
+        if fetch_cve == 2:
+            return config.fetch_cve
+        elif fetch_cve == 1:
             return True
-        elif onlycache == 0:
+        elif fetch_cve == 0:
             return False
 
         else:
-            raise RuntimeError("Invalid value %i for onlycache" % (onlycache))
+            raise RuntimeError("Invalid value %i for fetch_cve" % (fetch_cve))
 
     @dbus.service.method(dbus_interface=dbus_utils.DBUS_INTERFACE,
                          in_signature='bbiy', out_signature='s')
-    def scan_containers(self, onlyactive, allcontainers, number, onlycache=2):
-        """onlycache -
+    def scan_containers(self, onlyactive, allcontainers, number, fetch_cve=2):
+        """fetch_cve -
             0 to enable CVE fetch
             1 to disable CVE fetch
             2 to use defaults from oscapd config file
         """
         worker = Worker(onlyactive=onlyactive, allcontainers=allcontainers,
                         number=number,
-                        onlycache=self._parse_only_cache(self.system.config, int(onlycache)),
+                        fetch_cve=self._parse_only_cache(self.system.config, int(fetch_cve)),
                         fetch_cve_url=self.system.config.fetch_cve_url)
         return_json = worker.start_application()
         return json.dumps(return_json)
 
     @dbus.service.method(dbus_interface=dbus_utils.DBUS_INTERFACE, in_signature='bbiy',
                          out_signature='s')
-    def scan_images(self, allimages, images, number, onlycache=2):
-        """onlycache -
+    def scan_images(self, allimages, images, number, fetch_cve=2):
+        """fetch_cve -
             0 to enable CVE fetch
             1 to disable CVE fetch
             2 to use defaults from oscapd config file
         """
         worker = Worker(allimages=allimages, images=images,
                         number=number,
-                        onlycache=self._parse_only_cache(self.system.config, int(onlycache)),
+                        fetch_cve=self._parse_only_cache(self.system.config, int(fetch_cve)),
                         fetch_cve_url=self.system.config.fetch_cve_url)
         return_json = worker.start_application()
         return json.dumps(return_json)
 
     @dbus.service.method(dbus_interface=dbus_utils.DBUS_INTERFACE,
                          in_signature='asiy', out_signature='s')
-    def scan_list(self, scan_list, number, onlycache=2):
-        """onlycache -
+    def scan_list(self, scan_list, number, fetch_cve=2):
+        """fetch_cve -
             0 to enable CVE fetch
             1 to disable CVE fetch
             2 to use defaults from oscapd config file
         """
         worker = Worker(scan=scan_list, number=number,
-                        onlycache=self._parse_only_cache(self.system.config, int(onlycache)),
+                        fetch_cve=self._parse_only_cache(self.system.config, int(fetch_cve)),
                         fetch_cve_url=self.system.config.fetch_cve_url)
         return_json = worker.start_application()
         return json.dumps(return_json)


### PR DESCRIPTION
    The upstream openscap project changed the oscap_python code
    to pull the compressed OVAL files by default now.  This was done
    in openscap commit fab731df61feb7b5fc6b7ac906065dc051f8ff66.

    The OVAl file names also changed from something like
    'Red_Hat_Enterprise_Linux_7.xml' to 'com.redhat.rhsa-RHEL7.xml'
    which was causing the cve scans to fail.

    Lastly, while openscap itself can read in compressed file
    formats, python's ET cannot.  Small fix read in the compressed
    content prior to trying to parse the files.