### PR TITLE
Log evaluation args during atomic scan

### DIFF
--- a/openscap_daemon/cve_scanner/scan.py
+++ b/openscap_daemon/cve_scanner/scan.py
@@ -103,6 +103,11 @@ class Scan(object):
                '--results',
                os.path.join(self.report_dir,
                             self.image_name + '.xml'), self.chroot_cve_file]
+
+        logging.debug(
+            "Starting evaluation with command '%s'.",
+        " ".join(cmd))
+
         try:
             self.result = subprocess.check_output(cmd)
         except Exception:


### PR DESCRIPTION
```oscap``` called from ```daemon``` returns errors when I run "atomic scan".
This PR should help with solving issues like that.