### PR TITLE
Remove comments "used by atomic"

### DIFF
--- a/openscap_daemon/dbus_daemon.py
+++ b/openscap_daemon/dbus_daemon.py
@@ -389,8 +389,6 @@ class OpenSCAPDaemonDbus(dbus.service.Object):
             0 to enable CVE fetch
             1 to disable CVE fetch
             2 to use defaults from oscapd config file
-
-        Used by `atomic scan`. Do not break this interface!
         """
         worker = Worker(onlyactive=onlyactive, allcontainers=allcontainers,
                         number=number,

--- a/openscap_daemon/dbus_daemon.py
+++ b/openscap_daemon/dbus_daemon.py
@@ -406,8 +406,6 @@ class OpenSCAPDaemonDbus(dbus.service.Object):
             0 to enable CVE fetch
             1 to disable CVE fetch
             2 to use defaults from oscapd config file
-
-        Used by `atomic scan`. Do not break this interface!
         """
         worker = Worker(allimages=allimages, images=images,
                         number=number,


### PR DESCRIPTION
These functions are not used by Atomic. Atomic uses ```scan_list```
```
{master} zmoravec: /tmp/atomic 17:02:38
$ grep -r scan_containers;echo $?
1
{master} zmoravec: /tmp/atomic 17:04:57
$ grep -r scan_images;echo $?
1
{master} zmoravec: /tmp/atomic 17:05:01

```