### PR TITLE
Fix daemon hanging after unsuccessfull unmount [ updated ]

### DIFF
--- a/openscap_daemon/cve_scanner/cve_scanner.py
+++ b/openscap_daemon/cve_scanner/cve_scanner.py
@@ -298,8 +298,15 @@ class Worker(object):
             pass
 
         # umount and clean up temporary container
-        f.DM.unmount_path(f.dest)
-        f.DM._clean_temp_container_by_path(f.dest)
+        try:
+            f.DM.unmount_path(f.dest)
+            f.DM._clean_temp_container_by_path(f.dest)
+        except ValueError as e:
+            logging.error("Unmount error: {}".format(e.msg))
+        except Exception as e:
+            # We don't know all types of docker/atomic exception, so we catch
+            # all these exceptions to avoid daemon freezing
+            logging.error("Docker: {}".format(e.msg()))
 
         self.threads_complete += 1
         self.cur_scan_threads -= 1


### PR DESCRIPTION
It should fix daemon hanging after unsuccessful atomic unmount, but I am afraid that it can cause
https://github.com/projectatomic/atomic/issues/240 - I am not sure.

But I think that there is no much better solution for this problem in daemon.