### PR TITLE
Issue #48: Do not depend on Docker service

### DIFF
--- a/oscapd.service
+++ b/oscapd.service
@@ -1,8 +1,6 @@
 [Unit]
 Description=OpenSCAP Daemon
 Documentation=http://open-scap.org/tools/openscap-daemon
-After=docker.service
-Requires=docker.service
 
 [Service]
 Type=dbus


### PR DESCRIPTION
Deamon should not depend on Docker service.
It should be able to start without docker installed.