### PR TITLE
Catch an exception

### DIFF
--- a/openscap_daemon/cve_scanner/cve_scanner.py
+++ b/openscap_daemon/cve_scanner/cve_scanner.py
@@ -277,7 +277,16 @@ class Worker(object):
         sys.exit(0)
 
     def search_containers(self, image, cids, output):
-        f = Scan(image, cids, output, self.ac)
+        try:
+            f = Scan(image, cids, output, self.ac)
+        except Exception as e:
+            # We don't know all types of docker/atomic exception, so we catch
+            # all these exceptions to avoid daemon freezing
+            self.failed_scan = str(e)
+            self.threads_complete += 1
+            self.cur_scan_threads -= 1
+            return
+
         try:
             if f.get_release():
 


### PR DESCRIPTION
Deamon should not die on an exception in docker client.

This exception was observed during `atomic scan --images` on Fedora23.

Addressing:
```
Exception in thread ed695b131d039f3608c0da4335572f2e1a0ef490b9b67664d046cd6c835655de:
Traceback (most recent call last):
File "/usr/lib/python3.4/site-packages/docker/client.py", line 138, in _raise_for_status
response.raise_for_status()
File "/usr/lib/python3.4/site-packages/requests/models.py", line 840, in raise_for_status
raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: http+docker://localunixsocket/v1.20/containers/012d2e837331e17768b5f2df5
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
File "/usr/lib64/python3.4/threading.py", line 920, in _bootstrap_inner
self.run()
File "/usr/lib64/python3.4/threading.py", line 868, in run
self._target(*self._args, **self._kwargs)
File "/usr/lib/python3.4/site-packages/openscap_daemon/cve_scanner/cve_scanner.py", line 280, in search_containers
f = Scan(image, cids, output, self.ac)
File "/usr/lib/python3.4/site-packages/openscap_daemon/cve_scanner/scan.py", line 53, in __init__
self.dm_results = self.DM.mount(image_uuid)
File "/usr/lib/python3.4/site-packages/Atomic/mount.py", line 302, in mount
cid, dev_name = self._get_cid_from_mountpoint(self.mountpoint)
File "/usr/lib/python3.4/site-packages/Atomic/mount.py", line 494, in _get_cid_from_mountpoint
graph = self.client.inspect_container(c)["GraphDriver"]
File "/usr/lib/python3.4/site-packages/docker/utils/decorators.py", line 21, in wrapped
return f(self, resource_id, *args, **kwargs)
File "/usr/lib/python3.4/site-packages/docker/api/container.py", line 172, in inspect_container
self._get(self._url("/containers/{0}/json", container)), True
File "/usr/lib/python3.4/site-packages/docker/client.py", line 146, in _result
self._raise_for_status(response)
File "/usr/lib/python3.4/site-packages/docker/client.py", line 141, in _raise_for_status
raise errors.NotFound(e, response, explanation=explanation)
docker.errors.NotFound: 404 Client Error: Not Found ("b'no such id: 012d2e837331e17768b5f2df593a2a4471f8d5a87e7de35391eba2d35e6f4b24'")
```