### PR TITLE
error fixes

### DIFF
--- a/openscap_daemon/async.py
+++ b/openscap_daemon/async.py
@@ -21,6 +21,7 @@ import threading
 import logging
 import time
 import sys
+import traceback
 if sys.version_info < (3,):
     import Queue as queue
 else:
@@ -102,6 +103,8 @@ class AsyncManager(object):
                 logging.error("Action '%s' threw an exception that hasn't been "
                               "caught. This is most likely a bug, please"
                               "report it. %s" % (action, e))
+                exc_type, exc_value, tb = sys.exc_info()
+                traceback.print_tb(tb, file=sys.stderr)
 
             self.queue.task_done()
 

--- a/openscap_daemon/dbus_daemon.py
+++ b/openscap_daemon/dbus_daemon.py
@@ -488,7 +488,7 @@ class OpenSCAPDaemonDbus(dbus.service.Object):
         try:
             json_results = \
                 self.system.get_evaluate_cve_scanner_worker_async_results(token)
-            return (True, json_results)
+            return (True, json.dumps(json_results))
 
         except system.ResultsNotAvailable:
             return (False, "")


### PR DESCRIPTION
In this PR are many things, because it is lot of easier to manage / test if one fix doesn't incompatible with some other.

I am still testing/working on it. But you can review the changes.

This PL:

1. "Fix" problem with unknown container/image id.
 - It cause slower scanning now.
 - If somebody delete container during scan, issue will occur again
 - It should be quick&dirty solution, until we gen some beter

2. Fix python 2 issue with bad type of json output

3. Fix ID issue with new docker ID form "sha256:..."

4. Print traceback - helps me a lot. **Do you know any better form of the output?** (output from journalctl)

```
ERROR:Action 'Evaluate CVE Scanner Worker '<openscap_daemon.cve_scanner.cve_scanner.Worker object at 0x7fc498083668>'' threw an exception that hasn't been caught. This is most likely a bug, pleasereport it. Unable to associate sha256:e0cd0 with any image or container
  File "/usr/lib/python3.5/site-packages/openscap_daemon/async.py", line 100, in _worker_main
    action.run()
  File "/usr/lib/python3.5/site-packages/openscap_daemon/system.py", line 644, in run
    json_result = self.worker.start_application()
  File "/usr/lib/python3.5/site-packages/openscap_daemon/cve_scanner/cve_scanner.py", line 452, in start_application
    image_list = self._check_input(self.args.scan)
  File "/usr/lib/python3.5/site-packages/openscap_daemon/cve_scanner/cve_scanner.py", line 344, in _check_input
    raise ImageScannerClientError(error)
```

 