### PR TITLE
Issue #66: Daemon fails to start when configuration file is invalid

### DIFF
--- a/openscap_daemon/config.py
+++ b/openscap_daemon/config.py
@@ -153,7 +153,11 @@ class Configuration(object):
 
     def load(self, config_file):
         config = configparser.SafeConfigParser()
-        config.read(config_file)
+        try:
+            config.read(config_file)
+        except configparser.Error as e:
+            logging.error("Configuration file cannot be parsed. %s" % e)
+            return
 
         base_dir = os.path.dirname(config_file)
 


### PR DESCRIPTION
This commit catches an exception that appears if a wrong configuration
file is provided. The exception causes that daemon fails to start.