### PR TITLE
Remove -t option of "docker run" from SPC dockerfiles

### DIFF
--- a/atomic/centos7_spc/Dockerfile
+++ b/atomic/centos7_spc/Dockerfile
@@ -30,9 +30,9 @@ RUN yum -y install python-setuptools dbus-python && yum clean all && \
 
 ADD install.sh /root/
 
-LABEL INSTALL="docker run -t --rm --privileged -v /:/host/ IMAGE sh /root/install.sh"
+LABEL INSTALL="docker run --rm --privileged -v /:/host/ IMAGE sh /root/install.sh"
 
-LABEL RUN="docker run -dt --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /var/tmp/image-scanner:/var/tmp/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN --ipc=host IMAGE"
+LABEL RUN="docker run -d --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /var/tmp/image-scanner:/var/tmp/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN --ipc=host IMAGE"
 
 # Dockerfile reference discourages "ADD" with remote source
 # I would love to tag this with NOCACHE but Dockerfile doesn't have an

--- a/atomic/f22_spc/Dockerfile
+++ b/atomic/f22_spc/Dockerfile
@@ -10,9 +10,9 @@ RUN dnf -y install wget && dnf clean all
 
 ADD install.sh /root/
 
-LABEL INSTALL="docker run -t --rm --privileged -v /:/host/ IMAGE sh /root/install.sh"
+LABEL INSTALL="docker run --rm --privileged -v /:/host/ IMAGE sh /root/install.sh"
 
-LABEL RUN="docker run -dt --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /var/tmp/image-scanner:/var/tmp/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN --ipc=host IMAGE"
+LABEL RUN="docker run -d --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /var/tmp/image-scanner:/var/tmp/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN --ipc=host IMAGE"
 
 # Dockerfile reference discourages "ADD" with remote source
 # I would love to tag this with NOCACHE but Dockerfile doesn't have an

--- a/atomic/f23_spc/Dockerfile
+++ b/atomic/f23_spc/Dockerfile
@@ -10,9 +10,9 @@ RUN dnf -y install wget && dnf clean all
 
 ADD install.sh /root/
 
-LABEL INSTALL="docker run -t --rm --privileged -v /:/host/ IMAGE sh /root/install.sh"
+LABEL INSTALL="docker run --rm --privileged -v /:/host/ IMAGE sh /root/install.sh"
 
-LABEL RUN="docker run -dt --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /var/tmp/image-scanner:/var/tmp/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN --ipc=host IMAGE"
+LABEL RUN="docker run -d --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /var/tmp/image-scanner:/var/tmp/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN --ipc=host IMAGE"
 
 # Dockerfile reference discourages "ADD" with remote source
 # I would love to tag this with NOCACHE but Dockerfile doesn't have an

--- a/atomic/rhel7_spc/Dockerfile
+++ b/atomic/rhel7_spc/Dockerfile
@@ -20,9 +20,9 @@ RUN yum -y install wget && \
 
 ADD install.sh /root/
 
-LABEL INSTALL="docker run -t --rm --privileged -v /:/host/ IMAGE sh /root/install.sh"
+LABEL INSTALL="docker run --rm --privileged -v /:/host/ IMAGE sh /root/install.sh"
 
-LABEL RUN="docker run -dt --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /var/tmp/image-scanner:/var/tmp/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN --ipc=host IMAGE"
+LABEL RUN="docker run -d --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /var/tmp/image-scanner:/var/tmp/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN --ipc=host IMAGE"
 
 # Dockerfile reference discourages "ADD" with remote source
 # I would love to tag this with NOCACHE but Dockerfile doesn't have an


### PR DESCRIPTION
The -t option means to allocate a pseoudeterminal.
We don't need this feature for scanning so -t option is useless for us.