### PR TITLE
Clean up Dockerfiles

### DIFF
--- a/atomic/README.md
+++ b/atomic/README.md
@@ -3,16 +3,30 @@
 The daemon is containerized but has access to host resources. It can
 scan other containers, container images or even machines.
 
+## CentOS 7  in SPC
+```bash
+cd openscap-daemon/atomic
+docker build -t openscap-daemon-centos7 centos7_spc
+atomic install openscap-daemon-centos7
+atomic run openscap-daemon-centos7
+# at this point OpenSCAP Daemon dbus API is provided on the host
+# that means that you can run 'oscapd-cli' or 'atomic scan' on the host
+# and the SPC does the work
+atomic stop openscap-daemon-centos7
+# you can stop the SPC with the 'atomic stop' command
+```
+
 ## Fedora 22 in SPC
 ```bash
 cd openscap-daemon/atomic
 docker build -t openscap-daemon-f22 f22_spc
-# replace ID with the final ID that `docker build` gives you
-atomic install $ID
-atomic run $ID
+atomic install openscap-daemon-f22
+atomic run openscap-daemon-f22
 # at this point OpenSCAP Daemon dbus API is provided on the host
-# that means that you can run oscapd-cli or atomic scan on the host
+# that means that you can run 'oscapd-cli' or 'atomic scan' on the host
 # and the SPC does the work
+atomic stop openscap-daemon-f22
+# you can stop the SPC with the 'atomic stop' command
 ```
 
 ## Fedora 23 in SPC
@@ -20,26 +34,28 @@ You can build Fedora 23 based SPC in the same way as Fedora 22 based.
 ```bash
 cd openscap-daemon/atomic
 docker build -t openscap-daemon-f23 f23_spc
-# replace ID with the final ID that `docker build` gives you
-atomic install $ID
-atomic run $ID
+atomic install openscap-daemon-f23
+atomic run openscap-daemon-f23
 # at this point OpenSCAP Daemon dbus API is provided on the host
-# that means that you can run oscapd-cli or atomic scan on the host
+# that means that you can run 'oscapd-cli' or 'atomic scan' on the host
 # and the SPC does the work
+atomic stop openscap-daemon-f22
+# you can stop the SPC with the 'atomic stop' command
 ```
 
 ## RHEL7 in SPC
-Make sure the host machine is registered using subscription-manager
+Make sure the host machine is registered using 'subscription-manager'
 before you start. Otherwise you won't be able to install packages
 in the container.
 
 ```bash
 cd openscap-daemon/atomic
 docker build -t openscap-daemon-rhel7 rhel7_spc
-# replace ID with the final ID that `docker build` gives you
-atomic install $ID
-atomic run $ID
+atomic install openscap-daemon-rhel7
+atomic run openscap-daemon-rhel7
 # at this point OpenSCAP Daemon dbus API is provided on the host
-# that means that you can run oscapd-cli or atomic scan on the host
+# that means that you can run 'oscapd-cli' or 'atomic scan' on the host
 # and the SPC does the work
+atomic stop openscap-daemon-rhel7
+# you can stop the SPC with the 'atomic stop' command
 ```

--- a/atomic/centos7_spc/Dockerfile
+++ b/atomic/centos7_spc/Dockerfile
@@ -2,37 +2,25 @@
 
 FROM centos:7
 
-RUN yum -y update && yum -y groupinstall "Development Tools" && yum -y install make wget git && yum clean all
+ENV container docker
 
-RUN yum -y install scap-security-guide && yum clean all
-
-# TODO: Change to openscap package once 1.2.6 is everywhere
-RUN yum -y install autoconf automake libtool curl-devel libxml2-devel \
-    libxslt-devel pcre-devel libacl-devel libselinux-devel libcap-devel \
-    libblkid-devel bzip2-devel perl-XML-XPath bzip2 perl-XML-Parser swig \
-    python-devel && yum clean all && \
-    git clone -b maint-1.2 https://github.com/OpenSCAP/openscap.git && \
-    pushd /openscap && ./autogen.sh && \
-    ./configure --enable-sce --prefix=/usr && make -j 4 install && popd
-
-# TODO: Change to Atomic package once 1.4 is everywhere
-# PYLINT=/bin/true skips pylint checks
-RUN yum -y install python-setuptools dbus-python docker pygobject2 \
-    python-docker-py libselinux-python && yum clean all && \
-    git clone https://github.com/projectatomic/atomic.git && \
-    pushd /atomic && PREFIX=/usr PYLINT=/bin/true GO_MD2MAN=/bin/true \
-    make install && popd
-
-# TODO: Don't clone from scratch, instead add local working copy there
-RUN yum -y install python-setuptools dbus-python && yum clean all && \
-    git clone https://github.com/OpenSCAP/openscap-daemon && \
-    pushd /openscap-daemon && python setup.py install && popd
+# Install the EPEL repo and OpenSCAP copr repo, then install all our packages
+RUN cd /etc/yum.repos.d/ && \
+    rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    curl -O https://copr.fedorainfracloud.org/coprs/isimluk/OpenSCAP/repo/epel-7/isimluk-OpenSCAP-epel-7.repo && \
+    yum -y install \
+                atomic \
+                openscap-containers \
+                openscap-daemon \
+                scap-security-guide \
+                wget && \
+    yum clean all
 
 ADD install.sh /root/
 
 LABEL INSTALL="docker run --rm --privileged -v /:/host/ IMAGE sh /root/install.sh"
 
-LABEL RUN="docker run -d --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /var/tmp/image-scanner:/var/tmp/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN --ipc=host IMAGE"
+LABEL RUN="docker run -d --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /var/tmp/image-scanner:/var/tmp/image-scanner --net=host --cap-add=SYS_ADMIN --ipc=host --name NAME IMAGE"
 
 # Dockerfile reference discourages "ADD" with remote source
 # I would love to tag this with NOCACHE but Dockerfile doesn't have an
@@ -40,4 +28,4 @@ LABEL RUN="docker run -d --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /
 RUN wget --no-verbose -P /var/tmp/image-scanner/ \
     https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL{5,6,7}.xml.bz2
 
-CMD oscapd
+CMD ["/usr/bin/oscapd"]

--- a/atomic/f22_spc/Dockerfile
+++ b/atomic/f22_spc/Dockerfile
@@ -2,17 +2,21 @@
 
 FROM fedora:22
 
-RUN dnf -y install atomic && dnf clean all
+ENV container docker
 
-RUN dnf -y install openscap-containers scap-security-guide openscap-daemon && dnf clean all
-
-RUN dnf -y install wget && dnf clean all
+RUN dnf -y install \
+                atomic \
+                openscap-daemon \
+                openscap-containers \
+                scap-security-guide \
+                wget && \
+    dnf clean all
 
 ADD install.sh /root/
 
 LABEL INSTALL="docker run --rm --privileged -v /:/host/ IMAGE sh /root/install.sh"
 
-LABEL RUN="docker run -d --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /var/tmp/image-scanner:/var/tmp/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN --ipc=host IMAGE"
+LABEL RUN="docker run -d --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /var/tmp/image-scanner:/var/tmp/image-scanner --net=host --cap-add=SYS_ADMIN --ipc=host --name NAME IMAGE"
 
 # Dockerfile reference discourages "ADD" with remote source
 # I would love to tag this with NOCACHE but Dockerfile doesn't have an
@@ -20,4 +24,4 @@ LABEL RUN="docker run -d --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /
 RUN wget --no-verbose -P /var/tmp/image-scanner/ \
     https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL{5,6,7}.xml.bz2
 
-CMD oscapd
+CMD ["/usr/bin/oscapd"]

--- a/atomic/f23_spc/Dockerfile
+++ b/atomic/f23_spc/Dockerfile
@@ -2,17 +2,21 @@
 
 FROM fedora:23
 
-RUN dnf -y install atomic && dnf clean all
+ENV container docker
 
-RUN dnf -y install openscap-containers scap-security-guide openscap-daemon && dnf clean all
-
-RUN dnf -y install wget && dnf clean all
+RUN dnf -y install \
+                atomic \
+                openscap-containers \
+                openscap-daemon \
+                scap-security-guide \
+                wget && \
+    dnf clean all
 
 ADD install.sh /root/
 
 LABEL INSTALL="docker run --rm --privileged -v /:/host/ IMAGE sh /root/install.sh"
 
-LABEL RUN="docker run -d --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /var/tmp/image-scanner:/var/tmp/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN --ipc=host IMAGE"
+LABEL RUN="docker run -d --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /var/tmp/image-scanner:/var/tmp/image-scanner --net=host --cap-add=SYS_ADMIN --ipc=host --name NAME IMAGE"
 
 # Dockerfile reference discourages "ADD" with remote source
 # I would love to tag this with NOCACHE but Dockerfile doesn't have an
@@ -20,4 +24,4 @@ LABEL RUN="docker run -d --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /
 RUN wget --no-verbose -P /var/tmp/image-scanner/ \
     https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL{5,6,7}.xml.bz2
 
-CMD oscapd
+CMD ["/usr/bin/oscapd"]

--- a/atomic/rhel7_spc/Dockerfile
+++ b/atomic/rhel7_spc/Dockerfile
@@ -2,27 +2,32 @@
 
 FROM rhel7
 
-RUN yum -y update && \
-    yum-config-manager --enable rhel-7-server-optional-rpms rhel-7-server-extras-rpms && \
-    yum -y install atomic && \
-    yum clean all
+ENV container docker
 
-RUN cd /etc/yum.repos.d/ ; curl -O https://copr.fedorainfracloud.org/coprs/isimluk/OpenSCAP/repo/epel-7/isimluk-OpenSCAP-epel-7.repo && \
-    yum -y install openscap-containers scap-security-guide && \
-    yum clean all
-
-RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
-    yum -y install openscap-daemon && \
-    yum clean all
-
-RUN yum -y install wget && \
+# We have to generate yum cache for 'yum-config-manager' to work properly.
+# Then we disable all the repos and re-enable the few we are interested in.
+# Followed by installing the EPEL repo and the OpenSCAP copr repo.
+# Finally, we can install all our packages.
+RUN cd /etc/yum.repos.d/ && \
+    yum makecache && \
+    yum-config-manager --disable \* && \
+    yum-config-manager --enable rhel-7-server-rpms \
+                       --enable rhel-7-server-extras-rpms && \
+    rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+    curl -O https://copr.fedorainfracloud.org/coprs/isimluk/OpenSCAP/repo/epel-7/isimluk-OpenSCAP-epel-7.repo && \
+    yum -y install \
+                atomic \
+                openscap-containers \
+                openscap-daemon \
+                scap-security-guide \
+                wget && \
     yum clean all
 
 ADD install.sh /root/
 
 LABEL INSTALL="docker run --rm --privileged -v /:/host/ IMAGE sh /root/install.sh"
 
-LABEL RUN="docker run -d --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /var/tmp/image-scanner:/var/tmp/image-scanner --env container=docker --net=host --cap-add=SYS_ADMIN --ipc=host IMAGE"
+LABEL RUN="docker run -d --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /proc/:/hostproc/ -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/log:/var/log -v /run:/run -v /var/lib/docker/devicemapper/metadata/:/var/lib/docker/devicemapper/metadata/ -v /dev/:/dev/ -v /var/tmp/image-scanner:/var/tmp/image-scanner --net=host --cap-add=SYS_ADMIN --ipc=host --name NAME IMAGE"
 
 # Dockerfile reference discourages "ADD" with remote source
 # I would love to tag this with NOCACHE but Dockerfile doesn't have an
@@ -30,4 +35,4 @@ LABEL RUN="docker run -d --privileged --pid=host -v /etc/oscapd:/etc/oscapd -v /
 RUN wget --no-verbose -P /var/tmp/image-scanner/ \
     https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL{5,6,7}.xml.bz2
 
-CMD oscapd
+CMD ["/usr/bin/oscapd"]


### PR DESCRIPTION
This change aims to reduce the amount of layers when building the
various Docker images.

With the availability of `atomic` in the official distribution repos, we
are able install it via `yum`/`dnf` instead of building from source.

Additionally, we can install `openscap-daemon` from EPEL and
`openscap-containers` from the OpenSCAP copr repo maintained by
@isimluk, so we can avoid building them from source as well.

The formatting of the Dockerfiles is changed to (hopefully) improve the
readability of them.