### PR TITLE
Fixed typo that was causing schedule information not being written in tasks xml

### DIFF
--- a/openscap_daemon/system.py
+++ b/openscap_daemon/system.py
@@ -446,7 +446,7 @@ class System(object):
             task = self.tasks[task_id]
 
         with task.update_lock:
-            task.schedule_repeat_after = schedule_repeat_after
+            task.schedule.repeat_after = schedule_repeat_after
             task.save()
 
         logging.info(

--- a/openscap_daemon/system.py
+++ b/openscap_daemon/system.py
@@ -425,7 +425,7 @@ class System(object):
             task = self.tasks[task_id]
 
         with task.update_lock:
-            task.schedule_not_before = schedule_not_before
+            task.schedule.not_before = schedule_not_before
             task.save()
 
         logging.info(


### PR DESCRIPTION
Issue:

When a new task is created, schedule information is not well written:
```xml
<schedule repeat_after="0" slip_mode="drop_missed_aligned" />
```

With this PR:
```xml
<schedule not_before="2016-06-01T08:52" repeat_after="0" slip_mode="drop_missed_aligned" />
```