### PR TITLE
Issue #79: Fix oscapd-cli traceback

### DIFF
--- a/bin/oscapd-cli
+++ b/bin/oscapd-cli
@@ -634,7 +634,7 @@ def main():
             help="Create new task."
         )
         task_create_parser.add_argument(
-            "-i", "--interactive", action="store_true", dest="interactive"
+            "-i", "--interactive", action="store_true", dest="interactive", required=True
         )
     add_task_create_parser(subparsers)
 


### PR DESCRIPTION
In "oscapd-cli task-create", only interactive mode is possible now.
When run without "-i" user will be informed about a missing option
instead of seeing a traceback.