### PR TITLE
Issue #86: Do not show a traceback when user is not privileged

### DIFF
--- a/bin/oscapd-cli
+++ b/bin/oscapd-cli
@@ -762,6 +762,12 @@ def main():
                 "Warning: Can't perform version check, the openscap-daemon dbus"
                 " interface doesn't provide the GetVersion method.\n\n"
             )
+        elif e.get_dbus_name() == "org.freedesktop.DBus.Error.AccessDenied":
+            sys.stderr.write(
+                "Error: Access denied on the DBus interface. "
+                "Do you have required permissions?\n\n"
+            )
+            sys.exit(1)
         else:
             raise
 


### PR DESCRIPTION
When DBus access was denied, show a friendly error message.