### PR TITLE
Issue #91: Fix interactive task creating in Python 2.6

### DIFF
--- a/openscap_daemon/oscap_helpers.py
+++ b/openscap_daemon/oscap_helpers.py
@@ -79,7 +79,7 @@ def get_profile_choices_for_input(input_file, tailoring_file):
     ret = {}
 
     def scrape_profiles(tree, namespace, dest):
-        for elem in tree.iter("{%s}Profile" % (namespace)):
+        for elem in tree.findall(".//{%s}Profile" % (namespace)):
             id_ = elem.get("id")
             if id_ is None:
                 continue


### PR DESCRIPTION
ElementTree.iter() is not available in Python 2.6, it was introduced in 2.7.

Addressing:
```
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/dbus/service.py", line 702, in _message_cb
    retval = candidate_method(self, *args, **keywords)
  File "/usr/lib/python2.6/site-packages/openscap_daemon/dbus_daemon.py", line 78, in GetProfileChoicesForInput
    input_file, tailoring_file
  File "/usr/lib/python2.6/site-packages/openscap_daemon/system.py", line 86, in get_profile_choices_for_input
    input_file, tailoring_file
  File "/usr/lib/python2.6/site-packages/openscap_daemon/oscap_helpers.py", line 96, in get_profile_choices_for_input
    input_tree, "http://checklists.nist.gov/xccdf/1.1", ret
  File "/usr/lib/python2.6/site-packages/openscap_daemon/oscap_helpers.py", line 82, in scrape_profiles
    for elem in tree.iter("{%s}Profile" % (namespace)):
AttributeError: ElementTree instance has no attribute 'iter'
```