### PR TITLE
List security profiles applicable on a given target

### DIFF
--- a/bin/oscapd-evaluate
+++ b/bin/oscapd-evaluate
@@ -450,6 +450,18 @@ def main():
         "'docker-container://CONTAINER_ID', 'vm-domain://VM_NAME', "
         "'vm-image:///path/to/image.qcow2', 'chroot:///path/to/chroot'."
     )
+    target_profiles_parser = subparsers.add_parser(
+        "target-profiles",
+        help="Detect security profiles applicable on given target"
+    )
+    target_profiles_parser.add_argument(
+        "--target", type=str,
+        default="localhost",
+        help="Which target should we be checking. Possible choices include: "
+             "'localhost', 'ssh://user@machine', 'docker-image://IMAGE_ID', "
+             "'docker-container://CONTAINER_ID', 'vm-domain://VM_NAME', "
+             "'vm-image:///path/to/image.qcow2', 'chroot:///path/to/chroot'."
+    )
     scan_parser = subparsers.add_parser(
         "scan",
         help="Scan a list of targets for CVEs and configuration compliance, "
@@ -534,6 +546,20 @@ def main():
             args.target, config
         )
         print("\n".join(cpes))
+        sys.exit(0)
+
+    elif args.action == "target-profiles":
+        cpes = evaluation_spec.EvaluationSpec.detect_CPEs_of_target(
+            args.target, config
+        )
+        ssg_sds = config.get_ssg_sds(cpes)
+        print("Security profiles applicable on target " + args.target + ":")
+        profiles = oscap_helpers.get_profile_choices_for_input(ssg_sds, None)
+        for profile_id, title in profiles.items():
+            if profile_id:
+                print(title + " (id='" + profile_id + "')")
+            else:
+                print("Default Profile")
         sys.exit(0)
 
     elif args.action == "scan":

--- a/bin/oscapd-evaluate
+++ b/bin/oscapd-evaluate
@@ -452,7 +452,7 @@ def main():
     )
     target_profiles_parser = subparsers.add_parser(
         "target-profiles",
-        help="Detect security profiles applicable on given target"
+        help="Detect SCAP Security Guide profiles applicable on given target"
     )
     target_profiles_parser.add_argument(
         "--target", type=str,

--- a/man/oscapd-evaluate.8
+++ b/man/oscapd-evaluate.8
@@ -4,11 +4,11 @@
 oscapd-evaluate \- OpenSCAP-daemon one-off non-daemonized evaluator
 
 .SH SYNOPSIS
-\fBoscapd-evaluate\fR [\fI-h\fR] [\fI-v\fR] [\fI--verbose\fR] {config,xml,spec,target-cpes,scan}
+\fBoscapd-evaluate\fR [\fI-h\fR] [\fI-v\fR] [\fI--verbose\fR] {config,xml,spec,target-cpes,target-profiles,scan}
 
 .SS "positional arguments:"
 .IP
-{config,xml,spec,target\-cpes,scan}
+{config,xml,spec,target\-cpes,target\-profiles,scan}
 .TP
 config
 Generate default config file for oscapd and oscapd-evaluate.
@@ -21,6 +21,9 @@ Constructs Evaluation Spec from given parameters and evaluates it or outputs its
 .TP
 target\-cpes
 Detects CPEs of given target.
+.TP
+target\-profiles
+Detects configuration compliance profiles applicable on given target.
 .TP
 scan
 Performs CVE scan and/or configuration compliance evaluation of given targets. Outputs raw XML results and a summary JSON output.

--- a/man/oscapd-evaluate.8
+++ b/man/oscapd-evaluate.8
@@ -23,7 +23,7 @@ target\-cpes
 Detects CPEs of given target.
 .TP
 target\-profiles
-Detects configuration compliance profiles applicable on given target.
+Detects configuration compliance profiles from SCAP Security Guide applicable on given target.
 .TP
 scan
 Performs CVE scan and/or configuration compliance evaluation of given targets. Outputs raw XML results and a summary JSON output.

--- a/openscap_daemon/oscap_helpers.py
+++ b/openscap_daemon/oscap_helpers.py
@@ -79,7 +79,11 @@ def get_profile_choices_for_input(input_file, tailoring_file):
     ret = {}
 
     def scrape_profiles(tree, namespace, dest):
-        for elem in tree.findall(".//{%s}Profile" % (namespace)):
+        # TODO support multiple benchmarks in one DataStream
+        benchmark = tree.find(".//{%s}Benchmark" % (namespace))
+        if benchmark is None:
+            return
+        for elem in benchmark.findall(".//{%s}Profile" % (namespace)):
             id_ = elem.get("id")
             if id_ is None:
                 continue


### PR DESCRIPTION
This commit introduce 'oscapd-evaluate target-profiles' subcommand.
Similarly to 'oscapd-evaluate target-cpes', this will show a list
of available profiles to a scan target.