### PR TITLE
Allow to use SSG profile IDs without prefix

### DIFF
--- a/bin/oscapd-evaluate
+++ b/bin/oscapd-evaluate
@@ -103,6 +103,9 @@ def cli_scan(args, config):
     scanned_targets = []
     failed_targets = []
 
+    if not args.profile.startswith("xccdf_org.ssgproject.content_profile_"):
+        args.profile = "xccdf_org.ssgproject.content_profile_" + args.profile
+
     def scan_worker():
         while True:
             try:


### PR DESCRIPTION
Users will not have to type very long profile IDs, they can omit
the prefix and type only the profile name, and daemon will add
the prefix automatically.