### PR TITLE
Generate remediation script after scan

### DIFF
--- a/bin/oscapd-cli
+++ b/bin/oscapd-cli
@@ -452,6 +452,21 @@ def cli_result(dbus_iface, args):
                 args.task_id, args.result_id
             )
             print(report)
+        elif args.result_action == "bash_fix":
+            fix = dbus_iface.GenerateFixForTaskResult(
+                args.task_id, args.result_id, "bash"
+            )
+            print(fix)
+        elif args.result_action == "ansible_fix":
+            fix = dbus_iface.GenerateFixForTaskResult(
+                args.task_id, args.result_id, "ansible"
+            )
+            print(fix)
+        elif args.result_action == "puppet_fix":
+            fix = dbus_iface.GenerateFixForTaskResult(
+                args.task_id, args.result_id, "puppet"
+            )
+            print(fix)
         elif args.result_action == "remove":
             if args.force or confirm("Do you really want to remove result %d from task %d"
                                      % (args.result_id, args.task_id)):
@@ -697,7 +712,8 @@ def main():
         )
 
         result_actions = [
-            "arf", "stdout", "stderr", "exit_code", "report", "remove"
+            "arf", "stdout", "stderr", "exit_code", "report", "remove",
+            "bash_fix", "ansible_fix", "puppet_fix"
         ]
         result_parser.add_argument(
             "result_action", metavar="ACTION", type=str,

--- a/bin/oscapd-cli
+++ b/bin/oscapd-cli
@@ -248,6 +248,18 @@ def cli_task(dbus_iface, task_accessor, args):
             guide = dbus_iface.GenerateGuideForTask(args.task_id)
             print(guide)
 
+        elif args.task_action == "bash_fix":
+            fix = dbus_iface.GenerateFixForTask(args.task_id, "bash")
+            print(fix)
+
+        elif args.task_action == "ansible_fix":
+            fix = dbus_iface.GenerateFixForTask(args.task_id, "ansible")
+            print(fix)
+
+        elif args.task_action == "puppet_fix":
+            fix = dbus_iface.GenerateFixForTask(args.task_id, "puppet")
+            print(fix)
+
         elif args.task_action == "run":
             dbus_iface.RunTaskOutsideSchedule(args.task_id)
 
@@ -639,7 +651,8 @@ def main():
             "provided a summary of all tasks is displayed."
         )
 
-        task_actions = ["info", "guide", "run", "enable", "disable", "remove"]
+        task_actions = ["info", "guide", "run", "enable", "disable", "remove",
+                        "bash_fix", "ansible_fix", "puppet_fix"]
         task_actions += task_accessor.get_allowed()
 
         task_parser.add_argument(

--- a/bin/oscapd-evaluate
+++ b/bin/oscapd-evaluate
@@ -307,10 +307,16 @@ def cli_scan(args, config):
             )
             json_data["Profile"] = args.profile
 
-            with io.open(os.path.join(
-                    full_output_dir, "std.xml"), "w",
-                    encoding="utf-8") as f:
+            arf_filepath = os.path.join(full_output_dir, "arf.xml")
+            with io.open(arf_filepath, "w", encoding="utf-8") as f:
                 f.write(standard_scan_results)
+            if args.fix_type is not None:
+                fix_script = oscap_helpers.generate_fix_for_result(config, arf_filepath, args.fix_type)
+                suffixes = {"bash": "sh", "ansible": "yml", "puppet": "pp"}
+                fix_name = "fix." + suffixes[args.fix_type]
+                fix_filepath = os.path.join(full_output_dir, fix_name)
+                with io.open(fix_filepath, "w", encoding="utf-8") as f:
+                    f.write(fix_script)
 
         json_data["Scan Type"] = ", ".join(scan_type)
 
@@ -503,9 +509,15 @@ def main():
     scan_parser.add_argument(
         "--output", type=str, required=True,
         help="A directory where results will be stored in. There will be a "
-        "directory for each target created there with up to 3 files. 'json' "
-        "with json summary of the scan, cve.xml with CVE scan raw results and "
-        "std.xml with configuration compliance scan raw results."
+        "directory for each target created there with up to 4 files. 'json' "
+        "with json summary of the scan, cve.xml with CVE scan raw results, "
+        "arf.xml with configuration compliance scan raw results, and "
+        "fix.[sh|yml|pp] with a compliance remediation script."
+    )
+    scan_parser.add_argument(
+        "--fix_type", type=str,
+        choices=["bash", "ansible", "puppet"], default=None,
+        help="Specify the language of remediation script to be used."
     )
     args = parser.parse_args()
 

--- a/openscap_daemon/dbus_daemon.py
+++ b/openscap_daemon/dbus_daemon.py
@@ -151,6 +151,13 @@ class OpenSCAPDaemonDbus(dbus.service.Object):
         return self.system.generate_guide_for_task(task_id)
 
     @dbus.service.method(dbus_interface=dbus_utils.DBUS_INTERFACE,
+                         in_signature="xs", out_signature="s")
+    def GenerateFixForTask(self, task_id, fix_type):
+        """Generates and returns fix script for a task with given ID.
+        """
+        return self.system.generate_fix_for_task(task_id, fix_type)
+
+    @dbus.service.method(dbus_interface=dbus_utils.DBUS_INTERFACE,
                          in_signature="x", out_signature="")
     def RunTaskOutsideSchedule(self, task_id):
         """Given task will be run as soon as possible without affecting its

--- a/openscap_daemon/dbus_daemon.py
+++ b/openscap_daemon/dbus_daemon.py
@@ -382,6 +382,13 @@ class OpenSCAPDaemonDbus(dbus.service.Object):
         """
         return self.system.generate_report_for_task_result(task_id, result_id)
 
+    @dbus.service.method(dbus_interface=dbus_utils.DBUS_INTERFACE,
+                         in_signature="xxs", out_signature="s")
+    def GenerateFixForTaskResult(self, task_id, result_id, fix_type):
+        """Generates and returns remediation script for result of given task.
+        """
+        return self.system.generate_fix_for_task_result(task_id, result_id, fix_type)
+
     @dbus.service.method(dbus_interface=dbus_utils.DBUS_INTERFACE, in_signature='s',
                          out_signature='s')
     def inspect_container(self, cid):

--- a/openscap_daemon/evaluation_spec.py
+++ b/openscap_daemon/evaluation_spec.py
@@ -366,6 +366,12 @@ class EvaluationSpec(object):
 
         raise RuntimeError("Unknown EvaluationMode %i" % (self.mode))
 
+    def generate_fix(self, config, fix_type):
+        if self.mode in [oscap_helpers.EvaluationMode.SOURCE_DATASTREAM,
+                         oscap_helpers.EvaluationMode.STANDARD_SCAN]:
+            return oscap_helpers.generate_fix(self, config, fix_type)
+        raise RuntimeError("Unsupported EvaluationMode %i" % (self.mode))
+
     def get_oscap_guide_arguments(self, config):
         ret = []
 

--- a/openscap_daemon/system.py
+++ b/openscap_daemon/system.py
@@ -640,6 +640,17 @@ class System(object):
             self.config
         )
 
+    def generate_fix_for_task_result(self, task_id, result_id, fix_type):
+        task = None
+        with self.tasks_lock:
+            task = self.tasks[task_id]
+
+        return task.generate_fix_for_result(
+            result_id,
+            self.config,
+            fix_type
+        )
+
     class AsyncEvaluateCVEScannerWorkerAction(async.AsyncAction):
         def __init__(self, system, worker):
             super(System.AsyncEvaluateCVEScannerWorkerAction, self).__init__()

--- a/openscap_daemon/system.py
+++ b/openscap_daemon/system.py
@@ -577,6 +577,13 @@ class System(object):
 
         return task.evaluation_spec.generate_guide(self.config)
 
+    def generate_fix_for_task(self, task_id, fix_type):
+        task = None
+        with self.tasks_lock:
+            task = self.tasks[task_id]
+
+        return task.evaluation_spec.generate_fix(self.config, fix_type)
+
     def run_task_outside_schedule(self, task_id):
         task = None
         with self.tasks_lock:

--- a/openscap_daemon/task.py
+++ b/openscap_daemon/task.py
@@ -580,3 +580,12 @@ class Task(object):
             result_id,
             config
         )
+
+    def generate_fix_for_result(self, result_id, config, fix_type):
+        results_dir = self._get_task_results_dir(config.results_dir)
+        results_path = os.path.join(results_dir, str(result_id), "results.xml")
+        return oscap_helpers.generate_fix_for_result(
+            config,
+            results_path,
+            fix_type
+        )


### PR DESCRIPTION
We need a remediation script to be able to build hardened
images. Because we will need to use the script in Atomic,
which is independent on scanner, we can't call
"oscap xccdf generate fix" directly from Atomic.
Instead, we have to generate the fix right after the scan
by oscapd-evaluate.