### PR TITLE
Accept short profile IDs

### DIFF
--- a/bin/oscapd-evaluate
+++ b/bin/oscapd-evaluate
@@ -168,8 +168,9 @@ def cli_scan(args, config):
                         es.target = target
                         es.cpe_hints = cpes
                         ssg_sds = config.get_ssg_sds(cpes)
+                        es.input_.set_file_path(ssg_sds)
                         try:
-                            args.profile = es.select_profile_by_suffix(ssg_sds, args.profile)
+                            args.profile = es.select_profile_by_suffix(args.profile)
                         except RuntimeError:
                             logging.error(
                                 "Failed to find profile matching suffix '%s' "

--- a/bin/oscapd-evaluate
+++ b/bin/oscapd-evaluate
@@ -165,17 +165,16 @@ def cli_scan(args, config):
                     if not args.no_standard_compliance:
                         es = evaluation_spec.EvaluationSpec()
                         es.mode = oscap_helpers.EvaluationMode.STANDARD_SCAN
-                        es.profile_id = args.profile
                         es.target = target
                         es.cpe_hints = cpes
                         ssg_sds = config.get_ssg_sds(cpes)
-                        profiles = oscap_helpers.get_profile_choices_for_input(ssg_sds, None)
-                        if es.profile_id not in profiles:
-                            raise RuntimeError(
-                                "Profile with id='%s' doesn't exist on target '%s'. "
-                                "Get the available profiles using\n"
-                                "$ oscapd-evaluate target-profiles --target %s"
-                                % (es.profile_id, target, target)
+                        try:
+                            args.profile = es.select_profile_by_suffix(ssg_sds, args.profile)
+                        except RuntimeError:
+                            logging.error(
+                                "Failed to find profile matching suffix '%s' "
+                                "in profiles applicable to target '%s'."
+                                % (args.profile, target)
                             )
                         try:
                             standard_scan_results, stdout, stderr, exit_code = \

--- a/bin/oscapd-evaluate
+++ b/bin/oscapd-evaluate
@@ -24,6 +24,7 @@ from openscap_daemon import evaluation_spec
 from openscap_daemon import oscap_helpers
 from openscap_daemon import cli_helpers
 from openscap_daemon import version
+from openscap_daemon.evaluation_spec import ProfileSuffixMatchError
 
 import os
 import os.path
@@ -171,11 +172,11 @@ def cli_scan(args, config):
                         es.input_.set_file_path(ssg_sds)
                         try:
                             args.profile = es.select_profile_by_suffix(args.profile)
-                        except RuntimeError:
+                        except ProfileSuffixMatchError as e:
                             logging.error(
                                 "Failed to find profile matching suffix '%s' "
-                                "in profiles applicable to target '%s'."
-                                % (args.profile, target)
+                                "in profiles applicable to target '%s': %s"
+                                % (args.profile, target, e.message)
                             )
                         try:
                             standard_scan_results, stdout, stderr, exit_code = \

--- a/openscap_daemon/evaluation_spec.py
+++ b/openscap_daemon/evaluation_spec.py
@@ -351,13 +351,18 @@ class EvaluationSpec(object):
 
     def select_profile_by_suffix(self, ssg_sds, profile_suffix):
         profiles = oscap_helpers.get_profile_choices_for_input(ssg_sds, None)
+        profile_id_match = False
         for p in profiles:
             if p.endswith(profile_suffix):
-                self.profile_id = p
-                break
+                if profile_id_match:
+                    raise RuntimeError("Found multiple profiles with suffix %s." % profile_suffix)
+                else:
+                    self.profile_id = p
+                    profile_id_match = True
+        if profile_id_match:
+            return self.profile_id
         else:
             raise RuntimeError("No profile with suffix %s" % profile_suffix)
-        return self.profile_id
 
     def generate_guide(self, config):
         if self.mode == oscap_helpers.EvaluationMode.SOURCE_DATASTREAM:

--- a/openscap_daemon/evaluation_spec.py
+++ b/openscap_daemon/evaluation_spec.py
@@ -349,6 +349,16 @@ class EvaluationSpec(object):
 
         return cpe_ids
 
+    def select_profile_by_suffix(self, ssg_sds, profile_suffix):
+        profiles = oscap_helpers.get_profile_choices_for_input(ssg_sds, None)
+        for p in profiles:
+            if p.endswith(profile_suffix):
+                self.profile_id = p
+                break
+        else:
+            raise RuntimeError("No profile with suffix %s" % profile_suffix)
+        return self.profile_id
+
     def generate_guide(self, config):
         if self.mode == oscap_helpers.EvaluationMode.SOURCE_DATASTREAM:
             return oscap_helpers.generate_guide(self, config)

--- a/openscap_daemon/evaluation_spec.py
+++ b/openscap_daemon/evaluation_spec.py
@@ -358,14 +358,20 @@ class EvaluationSpec(object):
         for p in profiles:
             if p.endswith(profile_suffix):
                 if profile_id_match:
-                    raise RuntimeError("Found multiple profiles with suffix %s." % profile_suffix)
+                    raise ProfileSuffixMatchError(
+                        "Found multiple profiles with suffix %s." %
+                        profile_suffix
+                    )
                 else:
                     self.profile_id = p
                     profile_id_match = True
         if profile_id_match:
             return self.profile_id
         else:
-            raise RuntimeError("No profile with suffix %s" % profile_suffix)
+            raise ProfileSuffixMatchError(
+                "No profile with suffix %s" %
+                profile_suffix
+            )
 
     def generate_guide(self, config):
         if self.mode == oscap_helpers.EvaluationMode.SOURCE_DATASTREAM:
@@ -589,3 +595,7 @@ class EvaluationSpec(object):
                 cpe_ids.append(ref_id)
 
         return cpe_ids
+
+
+class ProfileSuffixMatchError(Exception):
+    pass

--- a/openscap_daemon/evaluation_spec.py
+++ b/openscap_daemon/evaluation_spec.py
@@ -349,8 +349,11 @@ class EvaluationSpec(object):
 
         return cpe_ids
 
-    def select_profile_by_suffix(self, ssg_sds, profile_suffix):
-        profiles = oscap_helpers.get_profile_choices_for_input(ssg_sds, None)
+    def select_profile_by_suffix(self, profile_suffix):
+        input_file = self.input_.file_path
+        if input_file is None:
+            raise RuntimeError("No SCAP content file was set in the EvaluationSpec")
+        profiles = oscap_helpers.get_profile_choices_for_input(input_file, None)
         profile_id_match = False
         for p in profiles:
             if p.endswith(profile_suffix):


### PR DESCRIPTION
Recently we implemented short profile IDs in OpenSCAP. However
oscapd-evaluate checks if the given profile ID is present
in SCAP Security Guide Datastream. We need to apply
suffix matching on the list of SSG profiles. Otherwise
we will get an error that the profile was not found.