### PR TITLE
generate-dockerfile.py: updated to use builds from Koji

### DIFF
--- a/generate-dockerfile.py
+++ b/generate-dockerfile.py
@@ -71,14 +71,27 @@ delim = " && \\\n    "
 
 def main():
     parser = argparse.ArgumentParser(description="Builds an image with OpenSCAP Daemon")
-    parser.add_argument("--base", type=str, default="fedora", help="Base image name")
-    parser.add_argument("--openscap-from-git", action="store_true", default=False,
-                        help="Use OpenSCAP from upstream instead of package")
-    parser.add_argument("--ssg-from-git", action="store_true", default=False,
-                        help="Use SCAP Security Guide from upstream instead of package")
-    parser.add_argument("--daemon-from-local", action="store_true", default=False,
-                        help="Use OpenSCAP Daemon from local working tree instead of package")
+    openscap_group = parser.add_mutually_exclusive_group(required=False)
+    ssg_group = parser.add_mutually_exclusive_group(required=False)
+    daemon_group = parser.add_mutually_exclusive_group(required=False)
+    parser.add_argument("--base", type=str, default="fedora",
+            help="Base image name (default is fedora)")
+    openscap_group.add_argument("--openscap-from-git", action="store_true",
+        default=False, help="Use OpenSCAP from upstream instead of package")
+    openscap_group.add_argument("--openscap-from-koji", type=str,
+        help="Use OpenSCAP from Koji based on build ID (Fedora only)")
+    ssg_group.add_argument("--ssg-from-koji", type=str,
+        help="Use SCAP Security Guide from Koji based on build ID (Fedora only)")
+    ssg_group.add_argument("--ssg-from-git", action="store_true", default=False,
+        help="Use SCAP Security Guide from upstream instead of package")
+    daemon_group.add_argument("--daemon-from-local", action="store_true", default=False,
+        help="Use OpenSCAP Daemon from local working tree instead of package")
+    daemon_group.add_argument("--daemon-from-koji", type=str,
+        help="Use OpenSCAP Daemon from Koji based on build ID (Fedora only)")
     args = parser.parse_args()
+    if (args.base != "fedora") and (args.openscap_from_koji != None
+        or args.ssg_from_koji != None or args.daemon_from_koji != None):
+            parser.error("Koji builds can be used only with fedora base image")
 
     f = open("Dockerfile", "w")
 
@@ -104,12 +117,24 @@ def main():
 
     build_from_source = []
     build_commands = []
+    koji_commands = []
+    install_from_koji = []
 
     # OpenSCAP
     if args.openscap_from_git:
         packages.extend(["git", "libtool", "automake"])
         build_from_source.append("openscap")
         build_commands.append(openscap_build_command)
+    elif args.openscap_from_koji != None:
+        packages.extend(["koji"])
+        install_from_koji.append("openscap")
+        openscap_koji_command = [
+            "koji download-build -a x86_64 {0}".format(args.openscap_from_koji),
+            "koji download-build -a noarch {0}".format(args.openscap_from_koji),
+            "{0} -y install openscap-[0-9]*.rpm openscap-scanner*.rpm openscap-utils*.rpm openscap-containers*.rpm".format(install_command),
+            "rm -f openscap-*.rpm"
+        ]
+        koji_commands.append(openscap_koji_command)
     else:
         packages.append("openscap-utils")
 
@@ -118,6 +143,15 @@ def main():
         packages.append("git")
         build_from_source.append("scap-security-guide")
         build_commands.append(ssg_build_command)
+    elif args.ssg_from_koji != None:
+        packages.extend(["koji"])
+        install_from_koji.append("scap-security-guide")
+        ssg_koji_command = [
+            "koji download-build -a noarch {0}".format(args.ssg_from_koji),
+            "{0} -y install scap-security-guide-[0-9]*.rpm".format(install_command),
+            "rm -f scap-security-guide*.rpm"
+        ]
+        koji_commands.append(ssg_koji_command)
     else:
         packages.append("scap-security-guide")
 
@@ -126,6 +160,15 @@ def main():
         build_from_source.append("openscap-daemon")
         build_commands.append(daemon_local_build_command)
         files.append((".","/openscap-daemon"))
+    elif args.daemon_from_koji != None:
+        packages.extend(["koji"])
+        install_from_koji.append("openscap-daemon")
+        daemon_koji_command = [
+            "koji download-build -a noarch {0}".format(args.daemon_from_koji),
+            "{0} -y install openscap-daemon*.rpm".format(install_command),
+            "rm -f openscap-daemon*.rpm"
+        ]
+        koji_commands.append(daemon_koji_command)
     else:
         packages.append("openscap-daemon")
 
@@ -147,16 +190,20 @@ def main():
         # install build dependencies
         f.write("RUN {0} {1}\n\n".format(builddep_command, " ".join(build_from_source)))
 
-    # clean package manager cache
-    f.write("RUN {0} clean all\n\n".format(install_command))
-
     if build_from_source:
         # add commands for building from custom sources
         for cmd in build_commands:
             f.write("RUN {0}\n\n".format(delim.join(cmd)))
 
+    if install_from_koji:
+        for cmd in koji_commands:
+            f.write("RUN {0}\n\n".format(delim.join(cmd)))
+
     # add RUN instruction that will download CVE feeds
     f.write("RUN {0}\n\n".format(delim.join(download_cve_feeds_command)))
+
+    # clean package manager cache
+    f.write("RUN {0} clean all\n\n".format(install_command))
 
     # add CMD instruction to the Dockerfile, including a comment
     f.write("# It doesn't matter what is in the line below, atomic will change the CMD\n")


### PR DESCRIPTION
* openscap, scap-security-guide and openscap-daemon can now be
  installed also by specifying build ID from Koji