### PR TITLE
Enable HTML reports in "oscapd-evaluate scan"

### DIFF
--- a/bin/oscapd-evaluate
+++ b/bin/oscapd-evaluate
@@ -319,6 +319,11 @@ def cli_scan(args, config):
                 fix_filepath = os.path.join(full_output_dir, fix_name)
                 with io.open(fix_filepath, "w", encoding="utf-8") as f:
                     f.write(fix_script)
+            if args.report:
+                report = oscap_helpers.generate_html_report_for_result(config, arf_filepath)
+                report_filepath = os.path.join(full_output_dir, "report.html")
+                with io.open(report_filepath, "w", encoding="utf-8") as f:
+                    f.write(report)
 
         json_data["Scan Type"] = ", ".join(scan_type)
 
@@ -520,6 +525,10 @@ def main():
         "--fix_type", type=str,
         choices=["bash", "ansible", "puppet"], default=None,
         help="Specify the language of remediation script to be used."
+    )
+    scan_parser.add_argument(
+        "--report", action="store_true", default=False,
+        help="Create HTML report in the output directory."
     )
     args = parser.parse_args()
 

--- a/openscap_daemon/oscap_helpers.py
+++ b/openscap_daemon/oscap_helpers.py
@@ -444,11 +444,8 @@ def _fix_type_to_template(fix_type):
     return template
 
 
-def generate_fix_for_result(config, results_path, fix_type):
-    if not os.path.exists(results_path):
-        raise RuntimeError("Can't generate fix for scan result. Expected "
-                           "results XML at '%s' but the file doesn't exist."
-                           % results_path)
+def _get_result_id(results_path):
+
     tree = ElementTree.parse(results_path)
     root = tree.getroot()
     ns = {"xccdf": "http://checklists.nist.gov/xccdf/1.2"}
@@ -457,6 +454,15 @@ def generate_fix_for_result(config, results_path, fix_type):
         raise RuntimeError("Results XML '%s' doesn't contain any results."
                            % results_path)
     result_id = test_result.attrib["id"]
+    return result_id
+
+
+def generate_fix_for_result(config, results_path, fix_type):
+    if not os.path.exists(results_path):
+        raise RuntimeError("Can't generate fix for scan result. Expected "
+                           "results XML at '%s' but the file doesn't exist."
+                           % results_path)
+    result_id = _get_result_id(results_path)
     template = _fix_type_to_template(fix_type)
     args = [config.oscap_path, "xccdf", "generate", "fix",
             "--result-id", result_id,

--- a/openscap_daemon/oscap_helpers.py
+++ b/openscap_daemon/oscap_helpers.py
@@ -472,6 +472,18 @@ def generate_fix_for_result(config, results_path, fix_type):
     return fix_text
 
 
+def generate_html_report_for_result(config, results_path):
+    if not os.path.exists(results_path):
+        raise RuntimeError("Can't generate report for scan result. Expected "
+                           "results XML at '%s' but the file doesn't exist."
+                           % results_path)
+    result_id = _get_result_id(results_path)
+    args = [config.oscap_path, "xccdf", "generate", "report",
+            "--result-id", result_id, results_path]
+    report_text = subprocess_check_output(args).decode("utf-8")
+    return report_text
+
+
 def generate_fix(spec, config, fix_type):
     if spec.mode not in [EvaluationMode.SOURCE_DATASTREAM,
                          EvaluationMode.STANDARD_SCAN]:

--- a/openscap_daemon/oscap_helpers.py
+++ b/openscap_daemon/oscap_helpers.py
@@ -445,7 +445,6 @@ def _fix_type_to_template(fix_type):
 
 
 def _get_result_id(results_path):
-
     tree = ElementTree.parse(results_path)
     root = tree.getroot()
     ns = {"xccdf": "http://checklists.nist.gov/xccdf/1.2"}

--- a/openscap_daemon/oscap_helpers.py
+++ b/openscap_daemon/oscap_helpers.py
@@ -453,8 +453,7 @@ def _get_result_id(results_path):
     if test_result is None:
         raise RuntimeError("Results XML '%s' doesn't contain any results."
                            % results_path)
-    result_id = test_result.attrib["id"]
-    return result_id
+    return test_result.attrib["id"]
 
 
 def generate_fix_for_result(config, results_path, fix_type):


### PR DESCRIPTION
Users of Atomic scan will be able to generate HTML report by adding `report` flag into their `--scanner_args` construction.

The HTML report is generated from ARF results.