### PR TITLE
container/remediate.py: remove intermediate containers during build process

### DIFF
--- a/container/remediate.py
+++ b/container/remediate.py
@@ -70,7 +70,9 @@ def remediate(target_id, results_dir):
                 path=temp_dir,
                 # don't use image cache to ensure that original image
                 # is always remediated
-                nocache=True
+                nocache=True,
+                # remove intermediate containers spawned during build
+                rm=True
             )
         except docker.errors.APIError as e:
             raise RuntimeError("Docker exception: {}\n".format(e))


### PR DESCRIPTION
This should cleanup intermediate containers from the system so they are not left hanging on the system when build of a hardened image is finished.