### PR TITLE
oscapd-evaluate: support xccdf-id option

### DIFF
--- a/bin/oscapd-evaluate
+++ b/bin/oscapd-evaluate
@@ -171,7 +171,9 @@ def cli_scan(args, config):
                         ssg_sds = config.get_ssg_sds(cpes)
                         es.input_.set_file_path(ssg_sds)
                         try:
-                            args.profile = es.select_profile_by_suffix(args.profile)
+                            args.profile = es.select_profile_by_suffix(
+                                None, args.profile
+                        )
                         except ProfileSuffixMatchError as e:
                             logging.error(
                                 "Failed to find profile matching suffix '%s' "
@@ -577,7 +579,9 @@ def main():
         )
         ssg_sds = config.get_ssg_sds(cpes)
         print("Security profiles applicable on target " + args.target + ":")
-        profiles = oscap_helpers.get_profile_choices_for_input(ssg_sds, None)
+        profiles = oscap_helpers.get_profile_choices_for_input(
+            ssg_sds, None, None
+        )
         for profile_id, title in profiles.items():
             if profile_id:
                 print(title + " (id='" + profile_id + "')")

--- a/bin/oscapd-evaluate
+++ b/bin/oscapd-evaluate
@@ -170,10 +170,11 @@ def cli_scan(args, config):
                         es.cpe_hints = cpes
                         ssg_sds = config.get_ssg_sds(cpes)
                         es.input_.set_file_path(ssg_sds)
+                        es.input_.xccdf_id = args.xccdf_id
                         try:
                             args.profile = es.select_profile_by_suffix(
-                                None, args.profile
-                        )
+                                args.xccdf_id, args.profile
+                            )
                         except ProfileSuffixMatchError as e:
                             logging.error(
                                 "Failed to find profile matching suffix '%s' "
@@ -315,7 +316,9 @@ def cli_scan(args, config):
             with io.open(arf_filepath, "w", encoding="utf-8") as f:
                 f.write(standard_scan_results)
             if args.fix_type is not None:
-                fix_script = oscap_helpers.generate_fix_for_result(config, arf_filepath, args.fix_type)
+                fix_script = oscap_helpers.generate_fix_for_result(
+                    config, arf_filepath, args.fix_type, args.xccdf_id
+                )
                 suffixes = {"bash": "sh", "ansible": "yml", "puppet": "pp"}
                 fix_name = "fix." + suffixes[args.fix_type]
                 fix_filepath = os.path.join(full_output_dir, fix_name)
@@ -510,6 +513,13 @@ def main():
         help="Skip the configuration compliance scan."
     )
     scan_parser.add_argument(
+        "--xccdf-id", type=str,
+        default=None,
+        help="ID of the XCCDF component in a datastream. Empty string is the "
+        "default and means that the first XCCDF component found in a "
+        "datastream will be used when looking for an XCCDF profile ID."
+    )
+    scan_parser.add_argument(
         "--profile", type=str,
         default="xccdf_org.ssgproject.content_profile_standard",
         help="Specify the profile ID for configuration compliance scan. "
@@ -580,7 +590,7 @@ def main():
         ssg_sds = config.get_ssg_sds(cpes)
         print("Security profiles applicable on target " + args.target + ":")
         profiles = oscap_helpers.get_profile_choices_for_input(
-            ssg_sds, None, None
+            ssg_sds, None, args.xccdf_id
         )
         for profile_id, title in profiles.items():
             if profile_id:

--- a/openscap_daemon/evaluation_spec.py
+++ b/openscap_daemon/evaluation_spec.py
@@ -349,11 +349,13 @@ class EvaluationSpec(object):
 
         return cpe_ids
 
-    def select_profile_by_suffix(self, profile_suffix):
+    def select_profile_by_suffix(self, xccdf_id, profile_suffix):
         input_file = self.input_.file_path
         if input_file is None:
             raise RuntimeError("No SCAP content file was set in the EvaluationSpec")
-        profiles = oscap_helpers.get_profile_choices_for_input(input_file, None)
+        profiles = oscap_helpers.get_profile_choices_for_input(
+            input_file, None, xccdf_id
+        )
         profile_id_match = False
         for p in profiles:
             if p.endswith(profile_suffix):

--- a/openscap_daemon/evaluation_spec.py
+++ b/openscap_daemon/evaluation_spec.py
@@ -481,6 +481,9 @@ class EvaluationSpec(object):
             if self.tailoring.file_path is not None:
                 ret.extend(["--tailoring-file", self.tailoring.file_path])
 
+            if self.input_.xccdf_id is not None:
+                ret.extend(["--xccdf-id", self.input_.xccdf_id])
+
             if self.profile_id is None:
                 ret.extend(["--profile",
                         "xccdf_org.ssgproject.content_profile_standard"])

--- a/openscap_daemon/oscap_helpers.py
+++ b/openscap_daemon/oscap_helpers.py
@@ -474,7 +474,7 @@ def _get_result_id(results_path):
     return test_result.attrib["id"]
 
 
-def generate_fix_for_result(config, results_path, fix_type):
+def generate_fix_for_result(config, results_path, fix_type, xccdf_id):
     if not os.path.exists(results_path):
         raise RuntimeError("Can't generate fix for scan result. Expected "
                            "results XML at '%s' but the file doesn't exist."
@@ -483,8 +483,10 @@ def generate_fix_for_result(config, results_path, fix_type):
     template = _fix_type_to_template(fix_type)
     args = [config.oscap_path, "xccdf", "generate", "fix",
             "--result-id", result_id,
-            "--template", template,
-            results_path]
+            "--template", template]
+    if xccdf_id is not None:
+        args.extend(["--xccdf-id", xccdf_id])
+    args.append(results_path)
     fix_text = subprocess_check_output(args).decode("utf-8")
     return fix_text
 

--- a/openscap_daemon/system.py
+++ b/openscap_daemon/system.py
@@ -87,7 +87,7 @@ class System(object):
 
     def get_profile_choices_for_input(self, input_file, tailoring_file):
         return oscap_helpers.get_profile_choices_for_input(
-            input_file, tailoring_file
+            input_file, tailoring_file, None
         )
 
     class AsyncEvaluateSpecAction(async.AsyncAction):

--- a/openscap_daemon/task.py
+++ b/openscap_daemon/task.py
@@ -587,5 +587,6 @@ class Task(object):
         return oscap_helpers.generate_fix_for_result(
             config,
             results_path,
-            fix_type
+            fix_type,
+            None
         )


### PR DESCRIPTION
atomic scan / oscapd-evaluate now supports `xccdf-id` scanner argument
for `configuration_compliance` scan type. This way it is possible to select
any profile in datastream file using:

    --scanner_args xccdf-id=XCCDF_ID,profile=PROFILE_ID

If `xccdf-id` is not specified, profile is selected from the first XCCDF
component found in a datastream file.

Fixes #116 