### PR TITLE
Support for atomic help feature

### DIFF
--- a/container/help.sh
+++ b/container/help.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+DOCKER="/usr/bin/docker"
+SELF=$1
+
+VERSION=$(${DOCKER} inspect -f '{{ index .Config.Labels "version" }}' ${SELF})
+RELEASE=$(${DOCKER} inspect -f '{{ index .Config.Labels "release" }}' ${SELF})
+if [ -z ${RELEASE} ]; then
+	echo -e "${SELF} image version: ${VERSION}\n"
+else
+	echo -e "${SELF} image version: ${VERSION}-${RELEASE}\n"
+fi
+
+DESCRIPTION=$(${DOCKER} inspect -f '{{ index .Config.Labels "description" }}' ${SELF})
+echo -e "Description:\n${DESCRIPTION}\n"
+
+echo "OpenSCAP packages bundled in ${SELF} image:"
+rpm -qa | grep openscap
+rpm -qa | grep scap-security-guide

--- a/generate-dockerfile.py
+++ b/generate-dockerfile.py
@@ -13,7 +13,8 @@ labels = [
     ("io.k8s.description", "OpenSCAP is an auditing tool that utilizes the Extensible Configuration Checklist Description Format (XCCDF). XCCDF is a standard way of expressing checklist content and defines security checklists."),
     ("io.openshift.tags", "security openscap scan"),
     ("install", "docker run --rm --privileged -v /:/host/ IMAGE sh /root/install.sh IMAGE"),
-    ("run", "docker run -it --rm -v /:/host/ IMAGE sh /root/run.sh")
+    ("run", "docker run -it --rm -v /:/host/ IMAGE sh /root/run.sh"),
+    ("help", "docker run --rm --privileged -v /usr/bin:/usr/bin -v /var/run:/var/run -v /lib:/lib -v /lib64:/lib64 -v /etc/sysconfig:/etc/sysconfig IMAGE sh /root/help.sh IMAGE")
 ]
 packages = [
     "bzip2",
@@ -24,7 +25,8 @@ files = [
     ("container/run.sh", "/root"),
     ("container/openscap", "/root"),
     ("container/config.ini", "/root"),
-    ("container/remediate.py", "/root")
+    ("container/remediate.py", "/root"),
+    ("container/help.sh", "/root")
 ]
 env_variables = [
     ("container", "docker")


### PR DESCRIPTION
* Added container/help.sh to print basic info about openscap image
      including its version and info about bundled OpenSCAP packages.
* generate-dockerfile.py extended to support atomic help feature
* Example usage:
      sudo atomic help openscap
  or:
      sudo atomic help openscap | grep version