### PR TITLE
Container image install now also sets image name into /etc/atomic.d/openscap

### DIFF
--- a/container/install.sh
+++ b/container/install.sh
@@ -3,12 +3,14 @@
 ETC='/etc/oscapd'
 ETC_FILE='config.ini'
 HOST='/host'
+SELF=$1
 
 echo ""
 echo "Installing the configuration file 'openscap' into /etc/atomic.d/.  You can now use this scanner with atomic scan with the --scanner openscap command-line option.  You can also set 'openscap' as the default scanner in /etc/atomic.conf.  To list the scanners you have configured for your system, use 'atomic scan --list'."
 
 echo ""
 cp /root/openscap /host/etc/atomic.d/
+sed -i "s|\$IMAGE_NAME|${SELF}|" /host/etc/atomic.d/openscap
 
 SCRIPTS="/etc/atomic.d/scripts/"
 echo ""

--- a/container/openscap
+++ b/container/openscap
@@ -1,6 +1,6 @@
 type: scanner
 scanner_name: openscap
-image_name: openscap
+image_name: $IMAGE_NAME
 default_scan: cve
 custom_args: ['-v', '/etc/oscapd:/etc/oscapd:ro']
 remediation_script: '/etc/atomic.d/scripts/remediate.py'

--- a/generate-dockerfile.py
+++ b/generate-dockerfile.py
@@ -12,7 +12,7 @@ labels = [
     ("io.k8s.display-name", "OpenSCAP"),
     ("io.k8s.description", "OpenSCAP is an auditing tool that utilizes the Extensible Configuration Checklist Description Format (XCCDF). XCCDF is a standard way of expressing checklist content and defines security checklists."),
     ("io.openshift.tags", "security openscap scan"),
-    ("install", "docker run --rm --privileged -v /:/host/ IMAGE sh /root/install.sh"),
+    ("install", "docker run --rm --privileged -v /:/host/ IMAGE sh /root/install.sh IMAGE"),
     ("run", "docker run -it --rm -v /:/host/ IMAGE sh /root/run.sh")
 ]
 packages = [


### PR DESCRIPTION
* When installing image using 'atomic install IMAGE_NAME', IMAGE_NAME was
  not added into configuration file /etc/atomic.d/openscap. This commit
  corrects it and properly installs the specified container image.

Fixes RHBZ 1440173