### PR TITLE
container/help.sh: never return non-zero return code

### DIFF
--- a/container/help.sh
+++ b/container/help.sh
@@ -15,5 +15,5 @@ DESCRIPTION=$(grep ' description=' $DOCKERFILE \
 echo -e "Description:\n${DESCRIPTION}\n"
 
 echo "OpenSCAP packages bundled in the image:"
-rpm -qa | grep openscap
-rpm -qa | grep scap-security-guide
+rpm -qa | grep openscap || true
+rpm -qa | grep scap-security-guide || true


### PR DESCRIPTION
The `container/help.sh` returned non-zero return code in cases when packages were deployed from git and there were no RPM packages installed inside the image. This behavior caused `atomic help` command to fail, therefore this PR makes `container/help.sh` to always return code `0`.