### PR TITLE
container/remediate.py: fix traceback caused by empty items in build_output_generator

### DIFF
--- a/container/remediate.py
+++ b/container/remediate.py
@@ -126,8 +126,12 @@ def remediate(target_id, results_dir):
                 raise RuntimeError(
                     "Error during Docker build {}\n".format(item_dict["error"])
                 )
-            sys.stdout.write(item_dict["stream"])
-            build_output.append(item_dict["stream"])
+            try:
+                sys.stdout.write(item_dict["stream"])
+                build_output.append(item_dict["stream"])
+            except KeyError:
+                # Skip empty items of build_output_generator.
+                pass
         image_id = build_output[-1].split()[-1]
 
         print(


### PR DESCRIPTION
Remediation script tracebacks which prevents remediation of a container image to finish successfully.

The traceback:
```
Remediating target 2779c0f20c2df6b700858dbddd9f21f08b2c6cd3f0a1f79a847d1b711660454a.
Step 1/3 : FROM 2779c0f20c2df6b700858dbddd9f21f08b2c6cd3f0a1f79a847d1b711660454a
 ---> 2779c0f20c2d
Step 2/3 : COPY fix.sh /
 ---> 9705a5fb8614
Removing intermediate container 2e97d4e7132d
Step 3/3 : RUN chmod +x /fix.sh; /fix.sh ; yum clean all
 ---> Running in ec6e5e935b11
Traceback (most recent call last):
  File "/etc/atomic.d/scripts/remediate.py", line 154, in <module>
    remediate(args.id, args.results_dir)
  File "/etc/atomic.d/scripts/remediate.py", line 129, in remediate
    sys.stdout.write(item_dict["stream"])
KeyError: 'stream'
```

The issue is that the latest docker low-level API returns a generator for the build output with an empty item which is not handled in `remediate.py` script.

The issue is reported in the RHBZ#1550948