### PR TITLE
Ignore any error from yum clean during remediation

### DIFF
--- a/container/remediate.py
+++ b/container/remediate.py
@@ -103,7 +103,7 @@ def remediate(target_id, results_dir):
             f.write("FROM " + target_id + "\n")
             f.write("COPY fix.sh /\n")
             f.write(
-                "RUN chmod +x /fix.sh; /fix.sh {}\n"
+                "RUN chmod +x /fix.sh; /fix.sh {}; true\n"
                 .format(pkg_clean_cmd)
             )
 

--- a/container/remediate.py
+++ b/container/remediate.py
@@ -102,6 +102,9 @@ def remediate(target_id, results_dir):
         with open(dockerfile_path, "w") as f:
             f.write("FROM " + target_id + "\n")
             f.write("COPY fix.sh /\n")
+            # Let's ignore any errors from package cleanup
+            # It may fail if the system has no connectivity
+            # or doesn't have a subscription.
             f.write(
                 "RUN chmod +x /fix.sh; /fix.sh {}; true\n"
                 .format(pkg_clean_cmd)


### PR DESCRIPTION
If host machine is not subscribed, command "yum clean all" executed after
remediation script will return error, and cause remediation of image to
be aborted.

Below is error from container remediation.
```
...
Remediating rule 13/14: 'xccdf_org.ssgproject.content_rule_accounts_password_pam_unix_remember'
Remediating rule 14/14: 'xccdf_org.ssgproject.content_rule_set_password_hashing_algorithm_libuserconf'
Loaded plugins: ovl, product-id, search-disabled-repos, subscription-manager
This system is not receiving updates. You can use subscription-manager on the host to register and assign subscriptions.
There are no enabled repos.
 Run "yum repolist all" to see the repos you have.
 To enable Red Hat Subscription Management repositories:
     subscription-manager repos --enable <repo>
 To enable custom repositories:
     yum-config-manager --enable <repo>
Cannot build remediated image from fd1ba0b398a82d56900bb798c8b099fbe3166bc49e2c5e947f7973cd38ff1a90: Error during Docker build The command '/bin/sh -c chmod +x /fix.sh; /fix.sh ; yum clean all' returned a non-zero code: 1
```
This patch prevents any error in "yum clean all" from aborting whole remediation.
Only thing that should happen if host machine is not subscribed, is that packages are not installed in remediated container image.