### PR TITLE
Python fixes

### DIFF
--- a/bin/oscapd-cli
+++ b/bin/oscapd-cli
@@ -546,7 +546,7 @@ def cli_scan(dbus_iface, args):
 
         else:
             if args.scan_targets:
-                raise NotImplemented(
+                raise NotImplementedError(
                     "This type of output is not implemented"
                     "for specified targets.\n"
                 )

--- a/container/remediate.py
+++ b/container/remediate.py
@@ -84,7 +84,7 @@ def remediate(target_id, results_dir):
         pkg_clean_cmd = "; dnf clean all"
     elif "redhat" in platform_cpe:
         try:
-            distro_version = int(re.search("\d+", platform_cpe).group(0))
+            distro_version = int(re.search(r"\d+", platform_cpe).group(0))
         except AttributeError:
             # In case it is not possible to extract rhel version, use yum.
             distro_version = 7

--- a/container/remediate.py
+++ b/container/remediate.py
@@ -76,7 +76,7 @@ def remediate(target_id, results_dir):
     try:
         ns = "http://checklists.nist.gov/xccdf/1.2"
         platform_cpe = root.find(
-            ".//{%s}TestResult/{%s}platform" %(ns, ns)
+            ".//{%s}TestResult/{%s}platform" % (ns, ns)
         ).attrib['idref']
     except AttributeError:
         pass

--- a/openscap_daemon/cve_scanner/applicationconfiguration.py
+++ b/openscap_daemon/cve_scanner/applicationconfiguration.py
@@ -48,7 +48,13 @@ class ApplicationConfiguration(object):
             error = "Can't import 'docker' package. Has docker been installed?"
             raise ImageScannerClientError(error)
 
-        client = docker.Client(base_url=host, timeout=11)
+        # Class docker.Client was renamed to docker.APIClient in
+        # python-docker-py 2.0.0.
+        try:
+            client = docker.APIClient(base_url=host, timeout=11)
+        except AttributeError:
+            client = docker.Client(base_url=host, timeout=11)
+
         if not client.ping():
             error = "Cannot connect to the Docker daemon. Is it running " \
                 "on this host?"

--- a/openscap_daemon/cve_scanner/scanner_client.py
+++ b/openscap_daemon/cve_scanner/scanner_client.py
@@ -66,7 +66,12 @@ class Client(object):
 
     @staticmethod
     def _docker_ping():
-        d_conn = docker.Client()
+        # Class docker.Client was renamed to docker.APIClient in
+        # python-docker-py 2.0.0.
+        try:
+            d_conn = docker.APIClient()
+        except AttributeError:
+            d_conn = docker.Client()
         try:
             d_conn.ping()
         except Exception:

--- a/openscap_daemon/dbus_daemon.py
+++ b/openscap_daemon/dbus_daemon.py
@@ -404,7 +404,12 @@ class OpenSCAPDaemonDbus(dbus.service.Object):
         Used by `atomic scan`. Do not break this interface!
         """
         import docker
-        docker_conn = docker.Client()
+        # Class docker.Client was renamed to docker.APIClient in
+        # python-docker-py 2.0.0.
+        try:
+            docker_conn = docker.APIClient()
+        except AttributeError:
+            docker_conn = docker.Client()
         inspect_data = docker_conn.inspect_container(cid)
         return json.dumps(inspect_data)
 
@@ -416,7 +421,12 @@ class OpenSCAPDaemonDbus(dbus.service.Object):
         Used by `atomic scan`. Do not break this interface!
         """
         import docker
-        docker_conn = docker.Client()
+        # Class docker.Client was renamed to docker.APIClient in
+        # python-docker-py 2.0.0.
+        try:
+            docker_conn = docker.APIClient()
+        except AttributeError:
+            docker_conn = docker.Client()
         inspect_data = docker_conn.inspect_image(iid)
         return json.dumps(inspect_data)
 
@@ -425,7 +435,12 @@ class OpenSCAPDaemonDbus(dbus.service.Object):
         """Used by `atomic scan`. Do not break this interface!
         """
         import docker
-        docker_conn = docker.Client()
+        # Class docker.Client was renamed to docker.APIClient in
+        # python-docker-py 2.0.0.
+        try:
+            docker_conn = docker.APIClient()
+        except AttributeError:
+            docker_conn = docker.Client()
         images = docker_conn.images(all=True)
         return json.dumps(images)
 
@@ -434,7 +449,12 @@ class OpenSCAPDaemonDbus(dbus.service.Object):
         """Used by `atomic scan`. Do not break this interface!
         """
         import docker
-        docker_conn = docker.Client()
+        # Class docker.Client was renamed to docker.APIClient in
+        # python-docker-py 2.0.0.
+        try:
+            docker_conn = docker.APIClient()
+        except AttributeError:
+            docker_conn = docker.Client()
         cons = docker_conn.containers(all=True)
         return json.dumps(cons)
 


### PR DESCRIPTION
During my transformation to Python 3, I have found some minor problems, but they affect both Python 2 and Python 3, not only Python 3.

They are:
* Class docker.Client was renamed to docker.APIClient in python-docker-py 2.0.0.
* We had an anomalous backslash in a string which turned out to be fixed by it should be raw string instead.
* We haven't risen a correct `NotImplementedError` exception.