### PR TITLE
Fix import cElementTree module

### DIFF
--- a/openscap_daemon/cli_helpers.py
+++ b/openscap_daemon/cli_helpers.py
@@ -21,7 +21,10 @@ import sys
 import os.path
 import logging
 from openscap_daemon import evaluation_spec
-from xml.etree import cElementTree as ElementTree
+try:
+    import xml.etree.cElementTree as ElementTree
+except ImportError:
+    import xml.etree.ElementTree as ElementTree
 
 if sys.version_info < (3,):
     py2_raw_input = raw_input

--- a/openscap_daemon/evaluation_spec.py
+++ b/openscap_daemon/evaluation_spec.py
@@ -21,7 +21,10 @@
 from openscap_daemon import et_helpers
 from openscap_daemon import oscap_helpers
 
-from xml.etree import cElementTree as ElementTree
+try:
+    import xml.etree.cElementTree as ElementTree
+except ImportError:
+    import xml.etree.ElementTree as ElementTree
 import os.path
 import tempfile
 import shutil

--- a/openscap_daemon/oscap_helpers.py
+++ b/openscap_daemon/oscap_helpers.py
@@ -24,7 +24,10 @@ import os.path
 import logging
 import io
 
-from xml.etree import cElementTree as ElementTree
+try:
+    import xml.etree.cElementTree as ElementTree
+except ImportError:
+    import xml.etree.ElementTree as ElementTree
 from openscap_daemon import et_helpers
 from openscap_daemon.compat import subprocess_check_output
 

--- a/openscap_daemon/task.py
+++ b/openscap_daemon/task.py
@@ -22,7 +22,10 @@ from openscap_daemon import et_helpers
 from openscap_daemon import oscap_helpers
 from openscap_daemon import evaluation_spec
 
-from xml.etree import cElementTree as ElementTree
+try:
+    import xml.etree.cElementTree as ElementTree
+except ImportError:
+    import xml.etree.ElementTree as ElementTree
 from datetime import datetime, timedelta
 import os.path
 import shutil


### PR DESCRIPTION
The xml.etree.cElementTree is deprecated since Python 3.3 and
it will be removed in Python 3.9. It can be replaced by
xml.etree.ElementTree. See https://bugs.python.org/issue36543.
We still want to import cElementTree when using Python 2,
so we will try to import it and if the import fails we will
use the latter.

Resolves: RHBZ#1817660