### PR TITLE
Add operator __lt__ to AsyncUpdateTaskAction class

### DIFF
--- a/openscap_daemon/system.py
+++ b/openscap_daemon/system.py
@@ -510,6 +510,9 @@ class System(object):
             return "Update Task '%i' with reference_datetime='%s'" \
                    % (self.task_id, self.reference_datetime)
 
+        def __lt__(a, b):
+            return a.reference_datetime < b.reference_datetime
+
     def schedule_tasks(self, reference_datetime=None):
         """Evaluates all currently outstanding tasks and returns.
         Outstanding task means it's not_before is lower than reference_datetime,


### PR DESCRIPTION
The AsyncManager class queue contain tuples with AsyncUpdateTaskAction
in it.
When a task is add in this queue, a comparison is made by a subfunction
of the queue management.
So the tuple comparison will fail with a TypeError Exception message.

Fix #153 