### PR TITLE
Drop reverence to deprecated SCAPtimony

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,6 @@ Features:
 * show past results of tasks
 * get ARFs, HTML reports for past results
 * set tasks to automatically push results to external result stores
-  * most importantly to [*scaptimony*](http://github.com/OpenSCAP/scaptimony)
 
 ### Foreman Integration
 Provide a way to reliably do one-off tasks. Unify various `oscap` runners into


### PR DESCRIPTION
SCAPtimony is deprecated. Perhaps the readme should mention Foreman instead? It's not clear if Foreman is a direct successor to this setup, though.